### PR TITLE
Datahandler

### DIFF
--- a/evaluateModels.py
+++ b/evaluateModels.py
@@ -16,9 +16,9 @@ import logging
 
 def get_training_inputs(variables, dataHandle, simHandle, rw_type=None, vars_dict=None):
     ###
-    X_d = dataHandle.get_dataset(variables)
+    X_d = dataHandle[variables]
     Y_d = util.labels_for_dataset(X_d, 1)
-    X_s = simHandle.get_dataset(variables)
+    X_s = simHandle[variables]
     Y_s = util.labels_for_dataset(X_s, 0)
 
     X = np.concatenate([X_d, X_s])

--- a/evaluateModels.py
+++ b/evaluateModels.py
@@ -151,12 +151,12 @@ def evaluateModels(**parsed_args):
     fnames_d = parsed_args['data']
     logger.info("(Pseudo) data files: {}".format(' '.join(fnames_d)))
     dataHandle = DataHandler(fnames_d, wname, variable_names=vars_det+vars_mc)
-    logger.info("Total number of pseudo data events: {}".format(dataHandle.get_nevents()))
+    logger.info("Total number of pseudo data events: {}".format(len(dataHandle)))
 
     fnames_s = parsed_args['signal']
     logger.info("Simulation files: {}".format(' '.join(fnames_s)))
     simHandle = DataHandler(fnames_s, wname, variable_names=vars_det+vars_mc)
-    logger.info("Total number of simulation events: {}".format(simHandle.get_nevents()))
+    logger.info("Total number of simulation events: {}".format(len(simHandle)))
 
     ####
     #dataHandle = DataToy(1000000, 1, 1.5)
@@ -261,8 +261,8 @@ def evaluateModels(**parsed_args):
         logger.info("  "+"    ".join(text_tria))
 
         # Compute KS test statistic
-        arr_truth = dataHandle.get_variable_arr(vname_mc)
-        arr_sim = simHandle.get_variable_arr(vname_mc)
+        arr_truth = dataHandle[vname_mc]
+        arr_sim = simHandle[vname_mc]
         text_ks = write_ks(arr_truth, w_d, [arr_sim, arr_sim], [w_s_rw, w_s], labels=['Reweighted', 'Prior'])
 
         logger.info("  "+"    ".join(text_ks))

--- a/evaluateModels.py
+++ b/evaluateModels.py
@@ -8,6 +8,7 @@ from sklearn.model_selection import train_test_split
 from model import get_model, get_callbacks
 
 from datahandler import DataHandler, DataToy
+import util
 from util import configGPUs, configRootLogger, expandFilePath, read_dict_from_json
 from util import get_bins, write_chi2, write_ks, write_triangular_discriminators, ks_2samp_weighted
 import plotting
@@ -15,8 +16,10 @@ import logging
 
 def get_training_inputs(variables, dataHandle, simHandle, rw_type=None, vars_dict=None):
     ###
-    X_d, Y_d = dataHandle.get_dataset(variables, 1)
-    X_s, Y_s = simHandle.get_dataset(variables, 0)
+    X_d = dataHandle.get_dataset(variables)
+    Y_d = util.labels_for_dataset(X_d, 1)
+    X_s = simHandle.get_dataset(variables)
+    Y_s = util.labels_for_dataset(X_s, 0)
 
     X = np.concatenate([X_d, X_s])
 

--- a/python/datahandler.py
+++ b/python/datahandler.py
@@ -290,14 +290,14 @@ class DataHandler(object):
             X = np.stack([self.get_features_array(varnames) for varnames in features], axis=1)
             return X
 
-    def get_dataset(self, features, label, standardize=False):
+    def get_dataset(self, features, standardize=False):
         """
+        Get a set of features from the dataset.
+
         Parameters
         ----------
         features : array-like of str
             Features to extract from the dataset.
-        label : int
-            Class number.
         standardize : bool, default: False
             Adjust the dataset so that the mean is 0 and standard deviation
             is 1.
@@ -306,8 +306,6 @@ class DataHandler(object):
         -------
         X : np.ndarray of shape (n_events, *features.shape)
             Extracted features.
-        Y : np.ndarray of shape (n_events,)
-            Class labels.
         """
         X = self.get_features_array(features)
 
@@ -317,10 +315,7 @@ class DataHandler(object):
             X -= Xmean
             X /= Xstd
 
-        # label
-        Y = np.full(len(X), label)
-
-        return X, Y
+        return X
 
     def get_correlations(self, variables):
         """

--- a/python/datahandler.py
+++ b/python/datahandler.py
@@ -93,8 +93,6 @@ class DataHandler(Mapping):
         provide the filename as "{path}*{reweight factor}".
     wname : str, default: "w"
         Name of the event weight column.
-    truth_known : bool, default: True
-        If the truth distribution is known.
     variable_names : list of str, optional
         List of variables to read. If not provided, read all variables in
         the dataset.
@@ -116,10 +114,15 @@ class DataHandler(Mapping):
         A file using reweighting doesn't contain `wname`.
     """
 
-    def __init__(self, filepaths, wname='w', truth_known=True,
-                 variable_names=None, vars_dict={}, array_name='arr_0'):
+    def __init__(
+        self,
+        filepaths,
+        wname="w",
+        variable_names=None,
+        vars_dict={},
+        array_name="arr_0",
+    ):
         self.weight_name = wname # name of event weights
-        self.truth_known = truth_known
 
         # load data from npz files to numpy array
         tmpDataArr = load_dataset(filepaths, array_name=array_name, weight_columns=wname)
@@ -437,7 +440,6 @@ class DataHandler(Mapping):
         elif rw_type == 'linear_th_pt':
             # truth-level hadronic top pt
             assert('th_pt' in vars_dict)
-            assert(self.truth_known)
             varname_thpt = vars_dict['th_pt']['branch_mc']
             th_pt = self[varname_thpt]
             # reweight factor
@@ -446,7 +448,6 @@ class DataHandler(Mapping):
         elif rw_type == 'gaussian_bump':
             # truth-level ttbar mass
             assert('mtt' in vars_dict)
-            assert(self.truth_known)
             varname_mtt = vars_dict['mtt']['branch_mc']
             mtt = self[varname_mtt]
             #reweight factor
@@ -457,7 +458,6 @@ class DataHandler(Mapping):
             return rw
         elif rw_type == 'gaussian_tail':
             assert('mtt' in vars_dict)
-            assert(self.truth_known)
             varname_mtt = vars_dict['mtt']['branch_mc']
             mtt = self[varname_mtt]
             #reweight factor
@@ -531,7 +531,6 @@ class DataToy(DataHandler):
     """
     def __init__(self, nevents, mu=0., sigma=1.):
         self.weight_name = ''
-        self.truth_known = True
 
         # generate toy data
         # truth level

--- a/python/datahandler.py
+++ b/python/datahandler.py
@@ -233,33 +233,6 @@ class DataHandler(Mapping):
             X = np.stack([self[varnames] for varnames in features], axis=1)
             return X
 
-    def get_dataset(self, features, standardize=False):
-        """
-        Get a set of features from the dataset.
-
-        Parameters
-        ----------
-        features : array-like of str
-            Features to extract from the dataset.
-        standardize : bool, default: False
-            Adjust the dataset so that the mean is 0 and standard deviation
-            is 1.
-
-        Returns
-        -------
-        X : np.ndarray of shape (n_events, *features.shape)
-            Extracted features.
-        """
-        X = self[features]
-
-        if standardize:
-            Xmean = np.mean(X, axis=0)
-            Xstd = np.std(X, axis=0)
-            X -= Xmean
-            X /= Xstd
-
-        return X
-
     def __iter__(self):
         """
         Create an iterator over the variable names in the dataset.
@@ -502,6 +475,39 @@ def _filter_variable_names(variable_names):
             varnames_skimmed.add(vname)
 
     return list(varnames_skimmed)
+
+def standardize_dataset(features):
+        """
+        Standardize the distribution of a set of features.
+
+        Adjust the dataset so that the mean is 0 and standard deviation is 1.
+
+        Parameters
+        ----------
+        features : array-like (n_events, *feature_shape)
+            Array of data. The data is interpreted as a series of feature
+            arrays, one per event. Standardization is performed along the
+            event axis.
+
+        Returns
+        -------
+        np.ndarray of shape (n_events, *feature_shape)
+            Standardized dataset.
+
+        Examples
+        --------
+        >>> a = np.asarray([
+        ...     [1, 2, 3],
+        ...     [4, 5, 6],
+        ... ])
+        >>> datahandler.standardize_dataset(a)
+        array([[-1., -1., -1.],
+               [ 1.,  1.,  1.]])
+        """
+        centred_at_zero = features - np.mean(features, axis=0)
+        deviation_one = centred_at_zero / np.std(centred_at_zero, axis=0)
+
+        return deviation_one
 
 # Toy data
 class DataToy(DataHandler):

--- a/python/datahandler.py
+++ b/python/datahandler.py
@@ -131,7 +131,7 @@ class DataHandler(object):
             if wname and not wname in variable_names:
                 variable_names.append(wname)
 
-            variable_names = self._filter_variable_names(variable_names)
+            variable_names = _filter_variable_names(variable_names)
 
             # check all variable names are available
             for vname in variable_names:
@@ -457,47 +457,47 @@ class DataHandler(object):
         else:
             raise RuntimeError("Unknown reweighting type: {}".format(rw_type))
 
-    def _filter_variable_names(self, variable_names):
-        """
-        Normalize a list of variables.
+def _filter_variable_names(variable_names):
+    """
+    Normalize a list of variables.
 
-        Replaces Cartesian variables with equivalent cylindrical variables
-        and removes duplicate variable names.
+    Replaces Cartesian variables with equivalent cylindrical variables
+    and removes duplicate variable names.
 
-        Parameters
-        ----------
-        variable_names : iterable of str
-            Variable names to process. If a variable ends in ``_px``,
-            ``_py``, or ``_pz``, it is interpreted as a Cartesian variable.
+    Parameters
+    ----------
+    variable_names : iterable of str
+        Variable names to process. If a variable ends in ``_px``,
+        ``_py``, or ``_pz``, it is interpreted as a Cartesian variable.
 
-        Returns
-        -------
-        list of str
-            Processed variable names. Not guaranteed to preserve order from
-            the input iterable.
-        """
-        varnames_skimmed = set()
+    Returns
+    -------
+    list of str
+        Processed variable names. Not guaranteed to preserve order from
+        the input iterable.
+    """
+    varnames_skimmed = set()
 
-        for vname in variable_names:
-            if '_px' in vname:
-                vname_pt = vname.replace('_px', '_pt')
-                vname_phi = vname.replace('_px', '_phi')
-                varnames_skimmed.add(vname_pt)
-                varnames_skimmed.add(vname_phi)
-            elif '_py' in vname:
-                vname_pt = vname.replace('_py', '_pt')
-                vname_phi = vname.replace('_py', '_phi')
-                varnames_skimmed.add(vname_pt)
-                varnames_skimmed.add(vname_phi)
-            elif '_pz' in vname:
-                vname_pt = vname.replace('_pz', '_pt')
-                vname_eta = vname.replace('_pz', '_eta')
-                varnames_skimmed.add(vname_pt)
-                varnames_skimmed.add(vname_eta)
-            else:
-                varnames_skimmed.add(vname)
+    for vname in variable_names:
+        if '_px' in vname:
+            vname_pt = vname.replace('_px', '_pt')
+            vname_phi = vname.replace('_px', '_phi')
+            varnames_skimmed.add(vname_pt)
+            varnames_skimmed.add(vname_phi)
+        elif '_py' in vname:
+            vname_pt = vname.replace('_py', '_pt')
+            vname_phi = vname.replace('_py', '_phi')
+            varnames_skimmed.add(vname_pt)
+            varnames_skimmed.add(vname_phi)
+        elif '_pz' in vname:
+            vname_pt = vname.replace('_pz', '_pt')
+            vname_eta = vname.replace('_pz', '_eta')
+            varnames_skimmed.add(vname_pt)
+            varnames_skimmed.add(vname_eta)
+        else:
+            varnames_skimmed.add(vname)
 
-        return list(varnames_skimmed)
+    return list(varnames_skimmed)
 
 # Toy data
 class DataToy(DataHandler):

--- a/python/omnifoldwbkg.py
+++ b/python/omnifoldwbkg.py
@@ -8,6 +8,7 @@ from sklearn.model_selection import train_test_split
 import plotting
 from datahandler import DataHandler
 from model import get_model, get_callbacks
+import util
 from util import add_histograms, write_chi2
 import logging
 logger = logging.getLogger('OmniFoldwBkg')
@@ -490,20 +491,24 @@ class OmniFoldwBkg(object):
 
     def _set_arrays_step1(self, standardize=False):
         # step 1: observed data vs simulation at detector level
-        X_obs, Y_obs = self.datahandle_obs.get_dataset(self.vars_reco, self.label_obs, standardize=False)
+        X_obs = self.datahandle_obs.get_dataset(self.vars_reco)
+        Y_obs = util.labels_for_dataset(X_obs, self.label_obs)
+
         if self.datahandle_obsbkg is not None:
             assert(self.datahandle_bkg is not None)
-            X_obsbkg, Y_obsbkg = self.datahandle_obsbkg.get_dataset(self.vars_reco, self.label_obs, standardize=False)
+            X_obsbkg = self.datahandle_obsbkg.get_dataset(self.vars_reco)
             X_obs = np.concatenate([X_obs, X_obsbkg])
             Y_obs = np.concatenate([Y_obs, Y_obsbkg])
 
-        X_sim, Y_sim = self.datahandle_sig.get_dataset(self.vars_reco, self.label_sig, standardize=False)
+        X_sim = self.datahandle_sig.get_dataset(self.vars_reco)
+        Y_sim = util.labels_for_dataset(X_sim, self.label_sig)
 
         if self.datahandle_bkg is None:
             self.X_step1 = np.concatenate([X_obs, X_sim])
             self.Y_step1 = np.concatenate([Y_obs, Y_sim])
         else:
-            X_simbkg, Y_simbkg = self.datahandle_bkg.get_dataset(self.vars_reco, self.label_bkg, standardize=False)
+            X_simbkg = self.datahandle_bkg.get_dataset(self.vars_reco)
+            Y_simbkg = util.labels_for_dataset(X_simbkg, self.label_bkg)
             self.X_step1 = np.concatenate([X_obs, X_sim, X_simbkg])
             self.Y_step1 = np.concatenate([Y_obs, Y_sim, Y_simbkg])
 
@@ -533,7 +538,7 @@ class OmniFoldwBkg(object):
 
     def _set_arrays_step2(self, standardize=False):
         # step 2: update simulation weights at truth level
-        self.X_gen = self.datahandle_sig.get_dataset(self.vars_truth, self.label_sig, standardize=False)[0]
+        self.X_gen = self.datahandle_sig.get_dataset(self.vars_truth)
         nsim = len(self.X_gen)
 
         if standardize:

--- a/python/omnifoldwbkg.py
+++ b/python/omnifoldwbkg.py
@@ -15,10 +15,19 @@ logger = logging.getLogger('OmniFoldwBkg')
 logger.setLevel(logging.DEBUG)
 
 class OmniFoldwBkg(object):
-    def __init__(self, variables_det, variables_truth, iterations=4, outdir='.', binned_rw=False):
+    def __init__(
+        self,
+        variables_det,
+        variables_truth,
+        iterations=4,
+        outdir=".",
+        binned_rw=False,
+        truth_known=True,
+    ):
         # list of detector and truth level variable names used in training
-        self.vars_reco = variables_det 
+        self.vars_reco = variables_det
         self.vars_truth = variables_truth
+        self.truth_known = truth_known
         # number of iterations
         self.iterations = iterations
         # reweighting method
@@ -205,7 +214,7 @@ class OmniFoldwBkg(object):
         hist_gen, hist_gen_err = self.datahandle_sig.get_histogram(varConfig['branch_mc'], self.weights_sim, bins)
 
         # MC truth if known
-        if self.datahandle_obs.truth_known:
+        if self.truth_known:
             # number of observed signal events
             nobs = len(self.datahandle_obs)
 
@@ -219,7 +228,7 @@ class OmniFoldwBkg(object):
 
         # compute chi2s
         text_td = []
-        if self.datahandle_obs.truth_known:
+        if self.truth_known:
             text_td = write_chi2(hist_truth, hist_truth_err, [hist_uf, hist_ibu, hist_gen], [hist_uf_err, hist_ibu_err, hist_gen_err], labels=['OmniFold', 'IBU', 'Prior'])
             logger.info("  "+"    ".join(text_td))
 
@@ -288,7 +297,7 @@ class OmniFoldwBkg(object):
                 hists_ibu, hists_ibu_err = [], []
 
             plotting.plot_iteration_diffChi2s(figname_prefix+"_diffChi2s", [hists_ibu, hists_uf], [hists_ibu_err, hists_uf_err], labels=["IBU", "OmniFold"])
-            if self.datahandle_obs.truth_known:
+            if self.truth_known:
                 plotting.plot_iteration_chi2s(figname_prefix+"_chi2s_wrt_Truth", hist_truth, hist_truth_err, [hists_ibu, hists_uf], [hists_ibu_err, hists_uf_err], labels=["IBU", "OmniFold"])
 
                 if self.unfolded_weights_resample is not None:
@@ -734,8 +743,15 @@ class OmniFoldwBkg(object):
 ###
 # Add background as negatively weighted data
 class OmniFoldwBkg_negW(OmniFoldwBkg):
-    def __init__(self, variables_det, variables_truth, iterations=4, outdir='.'):
-        super().__init__(variables_det, variables_truth, iterations, outdir)
+    def __init__(
+        self,
+        variables_det,
+        variables_truth,
+        iterations=4,
+        outdir=".",
+        truth_known=True
+    ):
+        super().__init__(variables_det, variables_truth, iterations, outdir, truth_known)
 
         # set background simulation label the same as data
         self.label_bkg = self.label_obs
@@ -751,8 +767,15 @@ class OmniFoldwBkg_negW(OmniFoldwBkg):
 ###
 # multi-class classification
 class OmniFoldwBkg_multi(OmniFoldwBkg):
-    def __init__(self, variables_det, variables_truth, iterations=4, outdir='.'):
-        super().__init__(variables_det, variables_truth, iterations, outdir)
+    def __init__(
+        self,
+        variables_det,
+        variables_truth,
+        iterations=4,
+        outdir=".",
+        truth_known=True,
+    ):
+        super().__init__(variables_det, variables_truth, iterations, outdir, truth_known)
 
         # new class label for background
         self.label_bkg = 2

--- a/python/omnifoldwbkg.py
+++ b/python/omnifoldwbkg.py
@@ -61,10 +61,16 @@ class OmniFoldwBkg(object):
             os.makedirs(outdir)
         self.outdir = outdir.rstrip('/')+'/'
 
-    def prepare_inputs(self, obsHandle, simHandle, bkgHandle=None,
-                        obsBkgHandle=None,
-                        plot_corr=False, standardize=False, reweight_type=None,
-                        vars_dict={}):
+    def prepare_inputs(
+        self,
+        obsHandle,
+        simHandle,
+        bkgHandle=None,
+        obsBkgHandle=None,
+        plot_corr=False,
+        standardize=False,
+        reweighter=None,
+    ):
         # observed data
         self.datahandle_obs = obsHandle
         logger.info(
@@ -108,8 +114,7 @@ class OmniFoldwBkg(object):
 
         # event weights for training
         logger.info("Prepare event weights")
-        self._set_event_weights(rw_type=reweight_type, vars_dict=vars_dict,
-                                rescale=True)
+        self._set_event_weights(reweighter)
 
         logger.info("Prepare arrays")
         # arrays for step 1
@@ -581,9 +586,9 @@ class OmniFoldwBkg(object):
             logger.info("Plot step 2 training variable {}".format(vname))
             plotting.plot_data_arrays(os.path.join(self.outdir, 'Train_step2_'+vname), [vgen], [wsig], labels=['Gen.'], title='Step-2 training inputs', xlabel=vname)
 
-    def _set_event_weights(self, rw_type=None, vars_dict={}, rescale=True):
-        self.weights_obs = self.datahandle_obs.get_weights(rw_type=rw_type,
-                                                           vars_dict=vars_dict)
+    def _set_event_weights(self, reweighter=None, rescale=True):
+        self.weights_obs = self.datahandle_obs.get_weights(reweighter=reweighter)
+
         if self.datahandle_obsbkg is not None:
             self.weights_obs = np.concatenate([self.weights_obs, self.datahandle_obsbkg.get_weights()])
 

--- a/python/omnifoldwbkg.py
+++ b/python/omnifoldwbkg.py
@@ -512,23 +512,23 @@ class OmniFoldwBkg(object):
 
     def _set_arrays_step1(self, standardize=False):
         # step 1: observed data vs simulation at detector level
-        X_obs = self.datahandle_obs.get_dataset(self.vars_reco)
+        X_obs = self.datahandle_obs[self.vars_reco]
         Y_obs = util.labels_for_dataset(X_obs, self.label_obs)
 
         if self.datahandle_obsbkg is not None:
             assert(self.datahandle_bkg is not None)
-            X_obsbkg = self.datahandle_obsbkg.get_dataset(self.vars_reco)
+            X_obsbkg = self.datahandle_obsbkg[self.vars_reco]
             X_obs = np.concatenate([X_obs, X_obsbkg])
             Y_obs = np.concatenate([Y_obs, Y_obsbkg])
 
-        X_sim = self.datahandle_sig.get_dataset(self.vars_reco)
+        X_sim = self.datahandle_sig[self.vars_reco]
         Y_sim = util.labels_for_dataset(X_sim, self.label_sig)
 
         if self.datahandle_bkg is None:
             self.X_step1 = np.concatenate([X_obs, X_sim])
             self.Y_step1 = np.concatenate([Y_obs, Y_sim])
         else:
-            X_simbkg = self.datahandle_bkg.get_dataset(self.vars_reco)
+            X_simbkg = self.datahandle_bkg[self.vars_reco]
             Y_simbkg = util.labels_for_dataset(X_simbkg, self.label_bkg)
             self.X_step1 = np.concatenate([X_obs, X_sim, X_simbkg])
             self.Y_step1 = np.concatenate([Y_obs, Y_sim, Y_simbkg])
@@ -559,7 +559,7 @@ class OmniFoldwBkg(object):
 
     def _set_arrays_step2(self, standardize=False):
         # step 2: update simulation weights at truth level
-        self.X_gen = self.datahandle_sig.get_dataset(self.vars_truth)
+        self.X_gen = self.datahandle_sig[self.vars_truth]
         nsim = len(self.X_gen)
 
         if standardize:

--- a/python/omnifoldwbkg.py
+++ b/python/omnifoldwbkg.py
@@ -58,22 +58,34 @@ class OmniFoldwBkg(object):
                         vars_dict={}):
         # observed data
         self.datahandle_obs = obsHandle
-        logger.info("Total number of observed events: {}".format(self.datahandle_obs.get_nevents()))
+        logger.info(
+            "Total number of observed events: {}".format(len(self.datahandle_obs))
+        )
 
         # simulation
         self.datahandle_sig = simHandle
-        logger.info("Total number of simulated events: {}".format(self.datahandle_sig.get_nevents()))
+        logger.info(
+            "Total number of simulated events: {}".format(len(self.datahandle_sig))
+        )
 
         # background simulation if needed
         self.datahandle_bkg = bkgHandle
         if self.datahandle_bkg is not None:
-            logger.info("Total number of simulated background events: {}".format(self.datahandle_bkg.get_nevents()))
+            logger.info(
+                "Total number of simulated background events: {}".format(
+                    len(self.datahandle_bkg)
+                )
+            )
 
         # background simulation to be mixed with data
         if self.datahandle_bkg is not None:
             self.datahandle_obsbkg = obsBkgHandle
             if self.datahandle_obsbkg is not None:
-                logger.info("Total number of background events mixed with data: {}".format(self.datahandle_obsbkg.get_nevents()))
+                logger.info(
+                    "Total number of background events mixed with data: {}".format(
+                        len(self.datahandle_obsbkg)
+                    )
+                )
 
         # plot input variable correlations
         if plot_corr:
@@ -154,7 +166,7 @@ class OmniFoldwBkg(object):
 
     def plot_distributions_reco(self, varname, varConfig, bins):
         # observed
-        nobs = self.datahandle_obs.get_nevents()
+        nobs = len(self.datahandle_obs)
         hist_obs, hist_obs_err = self.datahandle_obs.get_histogram(varConfig['branch_det'], self.weights_obs[:nobs], bins)
 
         if self.datahandle_obsbkg is not None:
@@ -195,7 +207,7 @@ class OmniFoldwBkg(object):
         # MC truth if known
         if self.datahandle_obs.truth_known:
             # number of observed signal events
-            nobs = self.datahandle_obs.get_nevents()
+            nobs = len(self.datahandle_obs)
 
             # Factor to rescale signal truth to signal sim
             # Should be 1 in case there is no background
@@ -411,7 +423,7 @@ class OmniFoldwBkg(object):
         if not nresamples > 1:
             return
 
-        self.unfolded_weights_resample = np.empty(shape=(nresamples, self.iterations, self.datahandle_sig.get_nevents()))
+        self.unfolded_weights_resample = np.empty(shape=(nresamples, self.iterations, len(self.datahandle_sig)))
         # shape: (nresamples, n_iterations, n_events)
 
         model_name = 'Models' if error_type=='bootstrap_stat' else 'Models_rs{}'

--- a/python/reweight.py
+++ b/python/reweight.py
@@ -1,0 +1,53 @@
+"""
+Reweighter definitions and handling.
+
+Attributes
+----------
+rw : dict
+    Mapping of reweighting name to `Reweighter` object. To register a new
+    reweighting, add it to `rw`.
+"""
+
+from dataclasses import dataclass
+from typing import Callable
+
+import numpy as np
+import numpy.typing as npt
+
+
+@dataclass
+class Reweighter:
+    """
+    A reweighting function and the variables it expects.
+
+    Attributes
+    ----------
+    func : callable(np.ndarray(nevents, *variables.shape)) -> np.ndarray(nevents,)
+        Reweighting function
+    variables : array-like of str
+        Features used in the reweighting
+    """
+
+    func: Callable[[npt.ArrayLike], np.ndarray]
+    variables: npt.ArrayLike
+
+
+def gaussian_bump(mtt):
+    k = 0.5
+    m0 = 800
+    sigma = 100
+    return 1 + k * np.exp(-(((mtt - m0) / sigma) ** 2))
+
+
+def gaussian_tail(mtt):
+    k = 0.5
+    m0 = 2000
+    sigma = 1000
+    return 1 + k * np.exp(-(((mtt - m0) / sigma) ** 2))
+
+
+rw = {
+    "linear_th_pt": Reweighter(lambda th_pt: 1 + th_pt / 800, "th_pt"),
+    "gaussian_bump": Reweighter(gaussian_bump, "mtt"),
+    "gaussian_tail": Reweighter(gaussian_tail, "mtt"),
+}

--- a/python/util.py
+++ b/python/util.py
@@ -404,3 +404,21 @@ def write_ks(data_ref, weights_ref, data_list, weights_list, labels):
         stamps.append("{} = {:.2e} ({:.3f})".format(l, ks, prob))
 
     return stamps
+
+def labels_for_dataset(array, label):
+    """
+    Make a label array for events in a dataset.
+
+    Parameters
+    ----------
+    array : sequence
+        Dataset of events.
+    label : int
+        Class label for events in the dataset.
+
+    Returns
+    -------
+    np.ndarray of shape (nevents,)
+        ndarray full of `label`
+    """
+    return np.full(len(array), label)

--- a/unfold.py
+++ b/unfold.py
@@ -171,14 +171,14 @@ def unfold(**parsed_args):
 
         # iterative Bayesian unfolding
         if True: # doIBU
-            array_obs = data_obs.get_variable_arr(varConfig['branch_det'])
+            array_obs = data_obs[varConfig['branch_det']]
             if data_obsbkg is not None:
-                array_obsbkg = data_obsbkg.get_variable_arr(varConfig['branch_det'])
+                array_obsbkg = data_obsbkg[varConfig['branch_det']]
                 array_obs = np.concatenate([array_obs, array_obsbkg])
 
-            array_sim = data_sig.get_variable_arr(varConfig['branch_det'])
-            array_gen = data_sig.get_variable_arr(varConfig['branch_mc'])
-            array_simbkg = data_bkg.get_variable_arr(varConfig['branch_det']) if data_bkg else None
+            array_sim = data_sig[varConfig['branch_det']]
+            array_gen = data_sig[varConfig['branch_mc']]
+            array_simbkg = data_bkg[varConfig['branch_det']] if data_bkg else None
             ibu = IBU(varname, bins_det, bins_mc,
                       array_obs, array_sim, array_gen, array_simbkg,
                       # use the same weights from OmniFold

--- a/unfold.py
+++ b/unfold.py
@@ -59,9 +59,7 @@ def unfold(**parsed_args):
     fnames_obs = parsed_args['data']
     logger.info("Data files: {}".format(' '.join(fnames_obs)))
     vars_obs = vars_det_all+vars_mc_all if parsed_args['truth_known'] else vars_det_all
-    data_obs = DataHandler(fnames_obs, wname,
-                            truth_known=parsed_args['truth_known'],
-                            variable_names = vars_obs)
+    data_obs = DataHandler(fnames_obs, wname, variable_names=vars_obs)
                             #vars_dict = observable_dict
 
     # mix background simulation for testing if needed
@@ -95,17 +93,29 @@ def unfold(**parsed_args):
     # Unfold
     #################
     if parsed_args['background_mode'] == 'default':
-        unfolder = OmniFoldwBkg(vars_det_train, vars_mc_train,
-                                iterations = parsed_args['iterations'],
-                                outdir = parsed_args['outputdir'])
+        unfolder = OmniFoldwBkg(
+            vars_det_train,
+            vars_mc_train,
+            iterations=parsed_args["iterations"],
+            outdir=parsed_args["outputdir"],
+            truth_known=parsed_args["truth_known"],
+        )
     elif parsed_args['background_mode'] == 'negW':
-        unfolder = OmniFoldwBkg_negW(vars_det_train, vars_mc_train,
-                                    iterations = parsed_args['iterations'],
-                                    outdir = parsed_args['outputdir'])
+        unfolder = OmniFoldwBkg_negW(
+            vars_det_train,
+            vars_mc_train,
+            iterations=parsed_args["iterations"],
+            outdir=parsed_args["outputdir"],
+            truth_known=parsed_args["truth_known"],
+        )
     elif parsed_args['background_mode'] == 'multiClass':
-        unfolder = OmniFoldwBkg_multi(vars_det_train, vars_mc_train,
-                                    iterations = parsed_args['iterations'],
-                                    outdir = parsed_args['outputdir'])
+        unfolder = OmniFoldwBkg_multi(
+            vars_det_train,
+            vars_mc_train,
+            iterations=parsed_args["iterations"],
+            outdir=parsed_args["outputdir"],
+            truth_known=parsed_args["truth_known"],
+        )
     else:
         logger.error("Unknown background mode {}".format(parsed_args['background_mode']))
 

--- a/unfold.py
+++ b/unfold.py
@@ -265,7 +265,7 @@ if __name__ == "__main__":
                         default='default', help="Background mode")
     parser.add_argument('-r', '--reweight-data', dest='reweight_data',
                         choices=reweight.rw.keys(), default=None,
-                        help="Reweight strategy of the input spectrum for stress tests")
+                        help="Reweight strategy of the input spectrum for stress tests. Requires --truth-known.")
     parser.add_argument('-v', '--verbose',
                         action='count', default=0,
                         help="Verbosity level")
@@ -297,6 +297,11 @@ if __name__ == "__main__":
     #                    help="Use alternative reweighting if true")
 
     args = parser.parse_args()
+
+    # Verify truth is known when reweighting
+    if args.reweight_data is not None and not args.truth_known:
+        print("--reweight-data requires --truth-known", file=sys.stderr)
+        sys.exit(2)
 
     logfile = os.path.join(args.outputdir, 'log.txt')
     configRootLogger(filename=logfile)


### PR DESCRIPTION
Major points:
* Use `collections.abc.Mapping` interface for `DataHandler`
  * `key in dh` works now; `len(dh)` gives number of events
  * Replace `get_variable_arr` and `get_features_array` with `__getitem__`:
    ```python
    >>> dh["var"] # -> np.ndarray(shape=(nevents,))
    >>> dh[["var1", "var2"]] # -> np.ndarray(shape=(nevents, 2))
    ```
  * Attempting to access an unknown variable name gives `KeyError` (like a dict) instead of `RuntimeError`
* Factor the reweighter functions out of datahandler.py into `reweight.py`. Rather than passing a reweighting name string and the observables configuration dict down to `DataHandler.get_weights`, instead pass a `Reweighter` object which encapsulates the reweighting function and the variable names it uses. The `reweight.rw` dict maps from reweighting name string to `Reweighter` objects
* Simplify the `DataHandler` interface:
  * Refactor `truth_known` into `OmniFoldwBkg`, which is the class that uses it
  * Decompose `DataHandler.get_dataset` to `util.labels_for_dataset` and `standardize_dataset`. Delete `DataHandler.get_dataset`.
  * `DataHandler._filter_variable_names` didn't actually use `self` so move it out of `DataHandler`.