### PR TITLE
Weights cleanup

### DIFF
--- a/python/omnifoldwbkg.py
+++ b/python/omnifoldwbkg.py
@@ -21,7 +21,6 @@ class OmniFoldwBkg(object):
         variables_truth,
         iterations=4,
         outdir=".",
-        binned_rw=False,
         truth_known=True,
     ):
         # list of detector and truth level variable names used in training
@@ -30,8 +29,6 @@ class OmniFoldwBkg(object):
         self.truth_known = truth_known
         # number of iterations
         self.iterations = iterations
-        # reweighting method
-        self.binned_rw = binned_rw
         # category labels
         self.label_obs = 1
         self.label_sig = 0
@@ -41,18 +38,6 @@ class OmniFoldwBkg(object):
         self.datahandle_sig = None
         self.datahandle_bkg = None
         self.datahandle_obsbkg = None
-        # arrays for training
-        self.X_step1 = None
-        self.Y_step1 = None
-        self.X_step2 = None
-        self.Y_step2 = None
-        # arrays for reweigting
-        self.X_sim = None
-        self.X_gen = None
-        # nominal event weights from samples
-        self.weights_obs = None
-        self.weights_sim = None
-        self.weights_bkg = None
         # unfoled weights
         self.unfolded_weights = None
         self.unfolded_weights_resample = None
@@ -68,7 +53,6 @@ class OmniFoldwBkg(object):
         bkgHandle=None,
         obsBkgHandle=None,
         plot_corr=False,
-        standardize=False,
         reweighter=None,
     ):
         # observed data
@@ -76,12 +60,22 @@ class OmniFoldwBkg(object):
         logger.info(
             "Total number of observed events: {}".format(len(self.datahandle_obs))
         )
+        if plot_corr:
+            logger.info("Plot input variable correlations")
+            corr_obs_reco = obsHandle.get_correlations(self.vars_reco)
+            plotting.plot_correlations(corr_obs_reco, os.path.join(self.outdir, 'correlations_det_obs'))
 
         # simulation
         self.datahandle_sig = simHandle
         logger.info(
             "Total number of simulated events: {}".format(len(self.datahandle_sig))
         )
+        if plot_corr:
+            logger.info("Plot input variable correlations")
+            corr_sim_reco = simHandle.get_correlations(self.vars_reco)
+            plotting.plot_correlations(corr_sim_reco, os.path.join(self.outdir, 'correlations_det_sig'))
+            corr_sim_gen = simHandle.get_correlations(self.vars_truth)
+            plotting.plot_correlations(corr_sim_gen, os.path.join(self.outdir, 'correlations_gen_sig'))
 
         # background simulation if needed
         self.datahandle_bkg = bkgHandle
@@ -92,7 +86,7 @@ class OmniFoldwBkg(object):
                 )
             )
 
-        # background simulation to be mixed with data
+        # background simulation to be mixed with pseudo data
         if self.datahandle_bkg is not None:
             self.datahandle_obsbkg = obsBkgHandle
             if self.datahandle_obsbkg is not None:
@@ -102,41 +96,301 @@ class OmniFoldwBkg(object):
                     )
                 )
 
-        # plot input variable correlations
-        if plot_corr:
-            logger.info("Plot input variable correlations")
-            corr_obs_reco = obsHandle.get_correlations(self.vars_reco)
-            plotting.plot_correlations(corr_obs_reco, os.path.join(self.outdir, 'correlations_det_obs'))
-            corr_sim_reco = simHandle.get_correlations(self.vars_reco)
-            plotting.plot_correlations(corr_sim_reco, os.path.join(self.outdir, 'correlations_det_sig'))
-            corr_sim_gen = simHandle.get_correlations(self.vars_truth)
-            plotting.plot_correlations(corr_sim_gen, os.path.join(self.outdir, 'correlations_gen_sig'))
-
-        # event weights for training
+        # prepare event weights
         logger.info("Prepare event weights")
         self._set_event_weights(reweighter)
 
-        logger.info("Prepare arrays")
-        # arrays for step 1
-        # self.X_step1, self.Y_step1, self.X_sim
-        self._set_arrays_step1(standardize)
+    def _set_event_weights(self, reweighter=None, rescale=True, plot=True):
+        """
+        preprocess event weights.
+        Reweight the pseudo data sample if reweighter is provided.
+        Rescale simulation weights to be consistent with data weights
 
-        # arrays for step 2
-        # self.X_step2, self.Y_step2, self.X_gen
-        self._set_arrays_step2(standardize)
+        Parameters
+        ----------
+        reweighter : reweight.Reweighter, optional
+            A function that takes events and returns event weights, and the
+            variables it expects.
+        rescale : bool, default: False
+            if True, rescale simulation sample weights to be compatible with
+            data
+        plot : bool, default: True
+            if True, plot distributions of event weights
+        """
+        logger.info("Preprocess event weights")
 
-    def run(self, error_type='sumw2', nresamples=0, load_previous_iteration=True,
-            batch_size=256, epochs=100):
-        assert(self.datahandle_obs is not None)
-        assert(self.datahandle_sig is not None)
+        # (pseudo) data weights
+        self.datahandle_obs.rescale_weights(reweighter=reweighter)
 
+        # total weights of data
+        sumw_obs = self.datahandle_obs.sum_weights()
+        if self.datahandle_obsbkg is not None:
+            sumw_obs += self.datahandle_obsbkg.sum_weights()
+
+        logger.debug("Total weights of data events: {}".format(sumw_obs))
+
+        if rescale:
+            logger.info("Rescale simulation prior weights to data")
+
+            # total weights of simulated events
+            sumw_sig = self.datahandle_sig.sum_weights()
+
+            sumw_bkg = 0.
+            if self.datahandle_bkg is not None:
+                sumw_bkg = self.datahandle_bkg.sum_weights()
+
+            sumw_sim = sumw_sig + sumw_bkg
+
+            self.datahandle_sig.rescale_weights( sumw_obs/sumw_sim )
+
+            if self.datahandle_bkg is not None:
+                self.datahandle_bkg.rescale_weights( sumw_obs/sumw_sim )
+
+        logger.debug(
+            "Total weights of simulated signal events: {}".format(
+                self.datahandle_sig.sum_weights()
+            )
+        )
+
+        if self.datahandle_bkg is not None:
+            logger.debug(
+                "Total weights of simulated background events: {}".format(
+                    self.datahandle_bkg.sum_weights()
+                )
+            )
+
+        if plot:
+            logger.info("Plot event weights")
+            plotting.plot_data_arrays(
+                os.path.join(self.outdir, 'Event_weights'),
+                [self.datahandle_sig.get_weights(), self.datahandle_obs.get_weights()],
+                labels=['Sim.', 'Data'], title='Event weights', xlabel='w'
+            )
+
+    def _get_event_weights(self, resample=False, plot=True):
+        """
+        Get event weights for training
+        """
+        logger.info("Get event weights for training")
+
+        # standardize data weights to mean of one
+        wobs = self.datahandle_obs.get_weights(bootstrap=resample)
+        if self.datahandle_obsbkg is not None:
+            wobsbkg = self.datahandle_obsbkg.get_weights(bootstrap=resample)
+            wobs = np.concatenate([wobs, wobsbkg])
+
+        logger.debug("Standardize data weights to mean of one")
+        wmean_obs = np.mean(wobs)
+        wobs /= wmean_obs
+
+        # simulation weights
+        wsig = self.datahandle_sig.get_weights()
+        wbkg = self.datahandle_bkg.get_weights() if self.datahandle_bkg is not None else None
+
+        # rescale simulation weights by the same factor
+        logger.debug("Scale simulation weights by the same factor as data")
+        wsig /= wmean_obs
+        if wbkg is not None:
+            wbkg /= wmean_obs
+
+        # TODO check the alternative: all weights are standardized
+        #wsig /= np.mean(wsig)
+        #if wbkg is not None:
+        #    wbkg /= np.mean(wbkg)
+
+        if plot and not resample:
+            logger.info("Plot the distribution of event weights used in training")
+            plotting.plot_data_arrays(
+                os.path.join(self.outdir, 'Event_weights_train'),
+                [wsig, wobs], labels=['Sim.', 'Data'],
+                title='Prior event weights in training', xlabel='w (training)'
+            )
+
+        return wobs, wsig, wbkg
+
+    def _get_feature_arrays_step1(self, preprocess=True, plot=False):
+        """
+        Get arrays for step 1 unfolding
+        setp 1: observed data vs simulation at detector level
+        """
+        X_obs = self.datahandle_obs[self.vars_reco]
+        if self.datahandle_obsbkg is not None:
+            X_obsbkg = self.datahandle_obsbkg[self.vars_reco]
+            X_obs = np.concatenate([X_obs, X_obsbkg])
+
+        X_sig = self.datahandle_sig[self.vars_reco]
+
+        if self.datahandle_bkg is not None:
+            X_bkg = self.datahandle_bkg[self.vars_reco]
+        else:
+            X_bkg = None
+
+        ####
+        # preprocess feature arrays
+        if preprocess:
+            logger.info("Preprocess feature arrays for step 1")
+
+            X_all = np.concatenate([X_obs, X_sig]) if X_bkg is None else np.concatenate([X_obs, X_sig, X_bkg])
+
+            # divide by their orders of magnitude
+            Xmean = np.mean(np.abs(X_all), axis=0)
+            Xoom = 10**(np.log10(Xmean).astype(int))
+            X_obs /= Xoom
+            X_sig /= Xoom
+            if X_bkg is not None:
+                X_bkg /= Xoom
+
+            # TODO: check alternatives
+            # e.g. standardize features to mean of zero and variance of one
+            #Xmean = np.mean(X_all, axis=0)
+            #Xstd = np.std(X_all, axis=0)
+            #
+            #X_obs -= Xmean
+            #X_obs /= Xstd
+            #X_sig -= Xmean
+            #X_sig /= Xstd
+            #if X_bkg is not None:
+            #    X_bkg -= Xmean
+            #    X_bkg /= Xstd
+
+        if plot:
+            logger.info("Plot the distribution of variables for step 1 training")
+            # weights
+            wobs, wsig = self._get_event_weights(plot=False)[:2]
+            for vname, vobs, vsig in zip(self.vars_reco, X_obs.T, X_sig.T):
+                logger.debug("  Plot variable {}".format(vname))
+                plotting.plot_data_arrays(
+                    os.path.join(self.outdir, "Train_step1_"+vname),
+                    [vsig, vobs], weight_arrs=[wsig, wobs],
+                    labels=['Sim.', 'Data'],
+                    title="Step-1 training inputs", xlabel=vname
+                )
+
+        return X_obs, X_sig, X_bkg
+
+    def _get_feature_arrays_step2(self, preprocess=True, plot=False):
+        """
+        Get arrays for step 2 unfolding
+        """
+        X_gen = self.datahandle_sig[self.vars_truth]
+
+        if preprocess:
+            logger.info("Preprocess feature arrays for step 2")
+            # # divide by their orders of magnitude
+            Xmean = np.mean(np.abs(X_gen), axis=0)
+            Xoom = 10**(np.log10(Xmean).astype(int))
+            X_gen /= Xoom
+
+            # TODO: check alternatives
+            #Xmean = np.mean(X_gen, axis=0)
+            #Xstd = np.std(X_gen, axis=0)
+            #X_gen -= Xmean
+            #X_gen /= Xstd
+
+        if plot:
+            logger.info("Plot the distribution of variables for step 2 training")
+            wsig = self._get_event_weights(plot=False)[1]
+            for vname, vgen in zip(self.vars_truth, X_gen.T):
+                logger.debug("  Plot variable {}".format(vname))
+                plotting.plot_data_arrays(
+                    os.path.join(self.outdir, "Train_step2_"+vname),
+                    [vgen], [wsig], labels=['Gen.'],
+                    title="Step-2 training inputs", xlabel=vname
+                )
+
+        return X_gen
+
+    def run(
+        self,
+        error_type='sumw2',
+        nresamples=0,
+        load_previous_iteration=True,
+        batch_size=256,
+        epochs=100
+    ):
+        """
+        Run unfolding
+        """
         fitargs = {'batch_size': batch_size, 'epochs': epochs, 'verbose': 1}
 
-        self.unfolded_weights = self._unfold(load_previous_iter=load_previous_iteration, fname_event_weights='weights.npz', **fitargs)
+        # Input arrays for step 1
+        logger.info("Get input arrays for step 1")
+        # features
+        X_obs, X_sim, X_bkg = self._get_feature_arrays_step1(
+            preprocess=True, plot=True)
 
-        # bootstrap uncertainty
-        if error_type in ['bootstrap_full', 'bootstrap_stat', 'bootstrap_model']:
-            self._unfold_resample(nresamples, error_type, load_previous_iteration, fname_event_weights='weights_resample{}.npz'.format(nresamples), **fitargs)
+        # labels
+        Y_obs = np.full(len(X_obs), self.label_obs)
+        Y_sim = np.full(len(X_sim), self.label_sig)
+        Y_bkg = None if X_bkg is None else np.full(len(X_bkg), self.label_bkg)
+
+        if X_bkg is None:
+            X_step1 = np.concatenate([X_obs, X_sim])
+            Y_step1 = np.concatenate([Y_obs, Y_sim])
+        else:
+            X_step1 = np.concatenate([X_obs, X_sim, X_bkg])
+            Y_step1 = np.concatenate([Y_obs, Y_sim, Y_bkg])
+
+        # make Y categorical
+        Y_step1 = tf.keras.utils.to_categorical(Y_step1)
+
+        logger.info("Size of the feature array for step 1: {:.3f} MB".format(
+            X_step1.nbytes*2**-20)
+        )
+        logger.info("Size of the label array for step 1: {:.3f} MB".format(
+            Y_step1.nbytes*2**-20)
+        )
+
+        # Input arrays for step 2
+        logger.info("Get input arrays for step 2")
+        # features
+        X_gen = self._get_feature_arrays_step2(preprocess=True, plot=True)
+        X_step2 = np.concatenate([X_gen, X_gen])
+
+        # labels
+        Y_step2 = np.concatenate([np.ones(len(X_gen)), np.zeros(len(X_gen))])
+        Y_step2 = tf.keras.utils.to_categorical(Y_step2)
+
+        logger.info("Size of the feature array for step 2: {:.3f} MB".format(
+            X_step2.nbytes*2**-20)
+        )
+        logger.info("Size of the label array for step 2: {:.3f} MB".format(
+            Y_step2.nbytes*2**-20)
+        )
+
+        # unfold
+        self.unfolded_weights = self._unfold(
+            X_step1, Y_step1, X_step2, Y_step2, X_sim, X_gen,
+            resample_data=False,
+            model_name="Models",
+            load_previous_iter=load_previous_iteration,
+            **fitargs
+        )
+
+        # save weights
+        wfile = os.path.join(self.outdir, 'weights.npz')
+        np.savez(wfile, weights = self.unfolded_weights)
+
+        # resamples
+        if error_type in ['bootstrap_full', 'bootstrap_model']:
+            self.unfolded_weights_resample = np.empty(
+                shape=( nresamples, self.iterations, len(X_sim) )
+            )
+
+            for ir in range(nresamples):
+                logger.info("Resample #{}".format(ir))
+                # unfold
+                self.unfolded_weights_resample[ir,:,:] = self._unfold(
+                    X_step1, Y_step1, X_step2, Y_step2, X_sim, X_gen,
+                    resample_data=(error_type=='bootstrap_full'),
+                    model_name="Models_rs{}".format(ir),
+                    load_previous_iter=load_previous_iteration,
+                    **fitargs
+                )
+
+            # save weights
+            wfile = os.path.join(self.outdir, 'weights_resample{}.npz'.format(nresamples))
+            np.savez(wfile, weights_resample = self.unfolded_weights_resample)
 
     def load(self, unfolded_weight_files):
         # load unfolded event weights from the saved file
@@ -157,7 +411,7 @@ class OmniFoldwBkg(object):
     def get_unfolded_distribution(self, variable, bins, all_iterations=False,
                                   bootstrap_uncertainty=True, normalize=True):
         ws = self.unfolded_weights if all_iterations else self.unfolded_weights[-1]
-        h_uf = self.datahandle_sig.get_histogram(variable, ws, bins)
+        h_uf = self.datahandle_sig.get_histogram(variable, bins, ws)
         # h_uf is a hist object or a list of hist objects
 
         bin_corr = None # bin correlations
@@ -186,33 +440,33 @@ class OmniFoldwBkg(object):
         if normalize:
             # renormalize the unfolded histograms and its error to the nominal signal simulation weights
             if all_iterations:
-                # rescale all iterations to self.weights_sim.sum()
-                rw = self.weights_sim.sum() / ws.sum(axis=1)
+                # rescale all iterations to simulation weights
+                rw = self.datahandle_sig.sum_weights() / ws.sum(axis=1)
                 for h, r in zip(h_uf, rw):
                     h *= r
             else:
-                h_uf *= self.weights_sim.sum() / ws.sum()
+                h_uf *= self.datahandle_sig.sum_weights() / ws.sum()
 
         return h_uf, bin_corr
 
     def plot_distributions_reco(self, varname, varConfig, bins):
         # observed
         nobs = len(self.datahandle_obs)
-        h_obs = self.datahandle_obs.get_histogram(varConfig['branch_det'], self.weights_obs[:nobs], bins)
+        h_obs = self.datahandle_obs.get_histogram(varConfig['branch_det'], bins)
 
         if self.datahandle_obsbkg is not None:
             # add background
-            h_obsbkg = self.datahandle_obsbkg.get_histogram(varConfig['branch_det'], self.weights_obs[nobs:], bins)
+            h_obsbkg = self.datahandle_obsbkg.get_histogram(varConfig['branch_det'], bins)
             h_obs = h_obs + h_obsbkg
 
         # signal simulation
-        h_sim = self.datahandle_sig.get_histogram(varConfig['branch_det'], self.weights_sim, bins)
+        h_sim = self.datahandle_sig.get_histogram(varConfig['branch_det'], bins)
 
         # background simulation
         if self.datahandle_bkg is None:
             h_simbkg = None
         else:
-            h_simbkg = self.datahandle_bkg.get_histogram(varConfig['branch_det'], self.weights_bkg, bins)
+            h_simbkg = self.datahandle_bkg.get_histogram(varConfig['branch_det'], bins)
 
         # plot
         figname = os.path.join(self.outdir, 'Reco_{}'.format(varname))
@@ -231,7 +485,7 @@ class OmniFoldwBkg(object):
             h_ibu, h_ibu_corr = None, None
 
         # signal prior distribution
-        h_gen = self.datahandle_sig.get_histogram(varConfig['branch_mc'], self.weights_sim, bins)
+        h_gen = self.datahandle_sig.get_histogram(varConfig['branch_mc'], bins)
 
         # MC truth if known
         if self.truth_known:
@@ -240,9 +494,9 @@ class OmniFoldwBkg(object):
 
             # Factor to rescale signal truth to signal sim
             # Should be 1 in case there is no background
-            f_sig = self.weights_sim.sum() / self.weights_obs[:nobs].sum()
+            #f_sig = self.weights_sim.sum() / self.weights_obs[:nobs].sum()
 
-            h_truth = self.datahandle_obs.get_histogram(varConfig['branch_mc'], self.weights_obs[:nobs]*f_sig, bins)
+            h_truth = self.datahandle_obs.get_histogram(varConfig['branch_mc'], bins)
         else:
             h_truth = None
 
@@ -257,7 +511,12 @@ class OmniFoldwBkg(object):
         if self.truth_known:
             arr_truth = self.datahandle_obs[varConfig['branch_mc']]
             arr_sim = self.datahandle_sig[varConfig['branch_mc']]
-            text_ks = write_ks(arr_truth, self.weights_obs[:nobs]*f_sig, [arr_sim, arr_sim], [self.unfolded_weights[-1], self.weights_sim], labels=['OmniFold', 'Prior'])
+            text_ks = write_ks(
+                arr_truth, self.datahandle_obs.get_weights(),
+                [arr_sim, arr_sim],
+                [self.unfolded_weights[-1], self.datahandle_sig.get_weights()],
+                labels=['OmniFold', 'Prior']
+            )
             logger.info("  "+"    ".join(text_ks))
 
         # plot
@@ -336,9 +595,19 @@ class OmniFoldwBkg(object):
 
                     plotting.plot_iteration_chi2s(figname_prefix+"_AllResamples_chi2s_wrt_Truth", h_truth, hists_uf_all, lw=0.7, ms=0.7)
 
-    def _unfold(self, resample_data=False, model_name='Models',
-                reweight_only=False, load_previous_iter=True,
-                val_size=0.2, fname_event_weights='weights.npz', **fitargs):
+    def _unfold(
+        self,
+        X_step1, Y_step1,
+        X_step2, Y_step2,
+        X_sim,
+        X_gen,
+        resample_data=False,
+        model_name='Models',
+        load_previous_iter=True,
+        val_size=0.2,
+        #fname_event_weights='weights.npz',
+        **fitargs
+    ):
         ################
         # model directory
         model_dir = os.path.join(self.outdir, model_name) if model_name else None
@@ -368,28 +637,27 @@ class OmniFoldwBkg(object):
             # step 1: reweight sim to look like data
             logger.info("Step 1")
             # set up the model for iteration i
-            model_step1, cb_step1 = self._set_up_model_step1(self.X_step1.shape[1:], i, model_dir, reweight_only, load_previous_iter)
+            model_step1, cb_step1 = self._set_up_model_step1(X_step1.shape[1:], i, model_dir, load_previous_iter)
 
-            if not reweight_only:
-                # prepare weight array for training
-                if wbkg is None:
-                    w_step1 = np.concatenate([wobs, wm_push])
-                else:
-                    w_step1 = np.concatenate([wobs, wm_push, wbkg])
-                assert(len(w_step1)==len(self.X_step1))
+            # prepare weight array for training
+            if wbkg is None:
+                w_step1 = np.concatenate([wobs, wm_push])
+            else:
+                w_step1 = np.concatenate([wobs, wm_push, wbkg])
+            assert(len(w_step1)==len(X_step1))
 
-                # split data into training and test sets
-                X_step1_train, X_step1_test, Y_step1_train, Y_step1_test, w_step1_train, w_step1_test = train_test_split(self.X_step1, self.Y_step1, w_step1, test_size=val_size)
+            # split data into training and test sets
+            X_step1_train, X_step1_test, Y_step1_train, Y_step1_test, w_step1_train, w_step1_test = train_test_split(X_step1, Y_step1, w_step1, test_size=val_size)
 
-                logger.info("Start training")
-                fname_preds1 = model_dir+'/preds_step1_{}'.format(i) if model_dir else None
-                self._train_model(model_step1, X_step1_train, Y_step1_train, w_step1_train, callbacks=cb_step1, val_data=(X_step1_test, Y_step1_test, w_step1_test), figname_preds=fname_preds1, **fitargs)
-                logger.info("Model training done")
+            logger.info("Start training")
+            fname_preds1 = model_dir+'/preds_step1_{}'.format(i) if model_dir else None
+            self._train_model(model_step1, X_step1_train, Y_step1_train, w_step1_train, callbacks=cb_step1, val_data=(X_step1_test, Y_step1_test, w_step1_test), figname_preds=fname_preds1, **fitargs)
+            logger.info("Model training done")
 
             # reweight
             logger.info("Reweighting")
-            fname_rhist1 = model_dir+'/rhist_step1_{}'.format(i) if model_dir and not reweight_only else None
-            wm_i = wm_push * self._reweight_step1(model_step1, self.X_sim, fname_rhist1)
+            fname_rhist1 = model_dir+'/rhist_step1_{}'.format(i) if model_dir else None
+            wm_i = wm_push * self._reweight_step1(model_step1, X_sim, fname_rhist1)
             # normalize the weight to the initial one
             #wm_i *= (wsim.sum()/wm_i.sum())
             logger.debug("Iteration {} step 1: wm.sum() = {}".format(i, wm_i.sum()))
@@ -401,24 +669,23 @@ class OmniFoldwBkg(object):
             # step 2: reweight the simulation prior to the learned weights
             logger.info("Step 2")
             # set up the model for iteration i
-            model_step2, cb_step2 = self._set_up_model_step2(self.X_step2.shape[1:], i, model_dir, reweight_only, load_previous_iter)
+            model_step2, cb_step2 = self._set_up_model_step2(X_step2.shape[1:], i, model_dir, load_previous_iter)
 
-            if not reweight_only:
-                # prepare weight array for training
-                w_step2 = np.concatenate([wt_pull, wsim])
+            # prepare weight array for training
+            w_step2 = np.concatenate([wt_pull, wsim])
 
-                # split data into training and test sets
-                X_step2_train, X_step2_test, Y_step2_train, Y_step2_test, w_step2_train, w_step2_test = train_test_split(self.X_step2, self.Y_step2, w_step2, test_size=val_size)
+            # split data into training and test sets
+            X_step2_train, X_step2_test, Y_step2_train, Y_step2_test, w_step2_train, w_step2_test = train_test_split(X_step2, Y_step2, w_step2, test_size=val_size)
 
-                # train model
-                logger.info("Start training")
-                fname_preds2 = model_dir+'/preds_step2_{}'.format(i) if model_dir else None
-                self._train_model(model_step2, X_step2_train, Y_step2_train, w_step2_train, callbacks=cb_step2, val_data=(X_step2_test, Y_step2_test, w_step2_test), figname_preds=fname_preds2, **fitargs)
+            # train model
+            logger.info("Start training")
+            fname_preds2 = model_dir+'/preds_step2_{}'.format(i) if model_dir else None
+            self._train_model(model_step2, X_step2_train, Y_step2_train, w_step2_train, callbacks=cb_step2, val_data=(X_step2_test, Y_step2_test, w_step2_test), figname_preds=fname_preds2, **fitargs)
 
             # reweight
             logger.info("Reweighting")
-            fname_rhist2 = model_dir+'/rhist_step2_{}'.format(i) if model_dir and not reweight_only else None
-            wt_i = wsim * self._reweight_step2(model_step2, self.X_gen, fname_rhist2)
+            fname_rhist2 = model_dir+'/rhist_step2_{}'.format(i) if model_dir else None
+            wt_i = wsim * self._reweight_step2(model_step2, X_gen, fname_rhist2)
             # normalize the weight to the initial one
             #wt_i *= (wsim.sum()/wt_i.sum())
             logger.debug("Iteration {} step 2: wt.sum() = {}".format(i, wt_i.sum()))
@@ -432,7 +699,7 @@ class OmniFoldwBkg(object):
 
         # rescale unfolded weights from training to the nominal sim weights
         logger.info("Rescale unfolded weights according to the nominal signal simulation weights and the weights used in the training")
-        weights_t *= self.weights_sim.sum() / wsim.sum()
+        weights_t *= self.datahandle_sig.sum_weights() / wsim.sum()
         logger.debug("Sum of unfolded weights = {}".format(weights_t[-1].sum()))
 
         # normalize unfolded weights to the nominal signal simulation weights
@@ -440,41 +707,14 @@ class OmniFoldwBkg(object):
         #weights_t *= (self.weights_sim.sum() / weights_t.sum(axis=1)[:,np.newaxis])
         #logger.debug("Sum of unfolded weights after normalization = {}".format(weights_t[-1].sum()))
 
-        # save the weights
-        if fname_event_weights:
-            weights_file = os.path.join(self.outdir, fname_event_weights)
-            np.savez(weights_file, weights = weights_t)
-
         # Plot training log
-        if model_dir and not reweight_only:
+        if model_dir:
             logger.info("Plot model training history")
             for csvfile in glob.glob(os.path.join(model_dir, '*.csv')):
                 logger.info("  Plot training log {}".format(csvfile))
                 plotting.plot_train_log(csvfile)
 
         return weights_t
-
-    def _unfold_resample(self, nresamples, error_type='bootstrap_full',
-                         load_previous_iter=True, fname_event_weights=None,
-                         **fitargs):
-        if not nresamples > 1:
-            return
-
-        self.unfolded_weights_resample = np.empty(shape=(nresamples, self.iterations, len(self.datahandle_sig)))
-        # shape: (nresamples, n_iterations, n_events)
-
-        model_name = 'Models' if error_type=='bootstrap_stat' else 'Models_rs{}'
-        reweight_only = True if error_type=='bootstrap_stat' else False
-        resample_data = False if error_type=='bootstrap_model' else True
-
-        for iresample in range(nresamples):
-            logger.info("Resample {}".format(iresample))
-            ws = self._unfold(resample_data, model_name.format(iresample), reweight_only, load_previous_iter, fname_event_weights=None, **fitargs)
-            self.unfolded_weights_resample[iresample,:,:] = ws
-
-        if fname_event_weights:
-            weights_file = os.path.join(self.outdir, fname_event_weights)
-            np.savez(weights_file, weights_resample = self.unfolded_weights_resample)
 
     def _get_unfolded_hists_resample(self, variable, bins, all_iterations=False, normalize=False):
         hists_resample = []
@@ -484,16 +724,16 @@ class OmniFoldwBkg(object):
             else:
                 ws = self.unfolded_weights_resample[iresample][-1]
 
-            h = self.datahandle_sig.get_histogram(variable, ws, bins)
+            h = self.datahandle_sig.get_histogram(variable, bins, ws)
 
             if normalize:
                 # rescale each iteration to the nominal signal simulation weights
                 if all_iterations:
-                    rw = self.weights_sim.sum()/ws.sum(axis=1)
+                    rw = self.datahandle_sig.sum_weights() / ws.sum(axis=1)
                     for hh, r in zip(h, rw):
                         hh *= r
                 else:
-                    rw = self.weights_sim.sum() / ws.sum()
+                    rw = self.datahandle_sig.sum_weights() / ws.sum()
                     h *= rw
 
             hists_resample.append(h)
@@ -507,134 +747,8 @@ class OmniFoldwBkg(object):
         wfile.close()
         return weights
 
-    def _set_arrays_step1(self, standardize=False):
-        # step 1: observed data vs simulation at detector level
-        X_obs = self.datahandle_obs[self.vars_reco]
-        Y_obs = util.labels_for_dataset(X_obs, self.label_obs)
-
-        if self.datahandle_obsbkg is not None:
-            assert(self.datahandle_bkg is not None)
-            X_obsbkg = self.datahandle_obsbkg[self.vars_reco]
-            X_obs = np.concatenate([X_obs, X_obsbkg])
-            Y_obs = np.concatenate([Y_obs, Y_obsbkg])
-
-        X_sim = self.datahandle_sig[self.vars_reco]
-        Y_sim = util.labels_for_dataset(X_sim, self.label_sig)
-
-        if self.datahandle_bkg is None:
-            self.X_step1 = np.concatenate([X_obs, X_sim])
-            self.Y_step1 = np.concatenate([Y_obs, Y_sim])
-        else:
-            X_simbkg = self.datahandle_bkg[self.vars_reco]
-            Y_simbkg = util.labels_for_dataset(X_simbkg, self.label_bkg)
-            self.X_step1 = np.concatenate([X_obs, X_sim, X_simbkg])
-            self.Y_step1 = np.concatenate([Y_obs, Y_sim, Y_simbkg])
-
-        if standardize:
-            logger.info("Standardize input feature arrays for step 1")
-            # divide by their order of magnitude
-            Xmean = np.mean(np.abs(self.X_step1), axis=0)
-            Xoom = 10**(np.log10(Xmean).astype(int))
-            self.X_step1 /= Xoom
-
-        X_obs = self.X_step1[:len(Y_obs)]
-        X_sim = self.X_step1[len(Y_obs):(len(Y_obs)+len(Y_sim))]
-        self.X_sim = X_sim
-
-        # make Y categorical
-        self.Y_step1 = tf.keras.utils.to_categorical(self.Y_step1)
-
-        logger.info("Size of the feature array for step 1: {:.3f} MB".format(self.X_step1.nbytes*2**-20))
-        logger.info("Size of the label array for step 1: {:.3f} MB".format(self.Y_step1.nbytes*2**-20))
-
-        # plot training variables
-        # event weights for training
-        wobs, wsim = self._get_event_weights()[:2]
-        for vname, vobs, vsim in zip(self.vars_reco, X_obs.T, X_sim.T):
-            logger.info("Plot step 1 training variable {}".format(vname))
-            plotting.plot_data_arrays(os.path.join(self.outdir, 'Train_step1_'+vname), [vsim, vobs], weight_arrs=[wsim, wobs], labels=['Sim.', 'Data'], title='Step-1 training inputs', xlabel=vname)
-
-    def _set_arrays_step2(self, standardize=False):
-        # step 2: update simulation weights at truth level
-        self.X_gen = self.datahandle_sig[self.vars_truth]
-        nsim = len(self.X_gen)
-
-        if standardize:
-            logger.info("Standardize input feature arrays for step 2")
-            Xmean = np.mean(np.abs(self.X_gen), axis=0)
-            Xoom = 10**(np.log10(Xmean).astype(int))
-            self.X_gen /= Xoom
-
-        self.X_step2 = np.concatenate([self.X_gen, self.X_gen])
-        self.Y_step2 = tf.keras.utils.to_categorical(np.concatenate([np.ones(nsim), np.zeros(nsim)]))
-
-        logger.info("Size of the feature array for step 2: {:.3f} MB".format(self.X_step2.nbytes*2**-20))
-        logger.info("Size of the label array for step 2: {:.3f} MB".format(self.Y_step2.nbytes*2**-20))
-
-        # plot training variables
-        # event weights for training
-        wsig = self._get_event_weights()[1]
-        for vname, vgen in zip(self.vars_truth, self.X_gen.T):
-            logger.info("Plot step 2 training variable {}".format(vname))
-            plotting.plot_data_arrays(os.path.join(self.outdir, 'Train_step2_'+vname), [vgen], [wsig], labels=['Gen.'], title='Step-2 training inputs', xlabel=vname)
-
-    def _set_event_weights(self, reweighter=None, rescale=True):
-        self.weights_obs = self.datahandle_obs.get_weights(reweighter=reweighter)
-
-        if self.datahandle_obsbkg is not None:
-            self.weights_obs = np.concatenate([self.weights_obs, self.datahandle_obsbkg.get_weights()])
-
-        self.weights_sim = self.datahandle_sig.get_weights()
-        self.weights_bkg = None if self.datahandle_bkg is None else self.datahandle_bkg.get_weights()
-
-        # plot original event weights
-        logger.info("Plot original event weights")
-        plotting.plot_data_arrays(os.path.join(self.outdir, 'Event_weights'), [self.weights_sim, self.weights_obs], labels=['Sim.', 'Data'], title='Original event weights', xlabel='w')
-
-        # rescale signal and background simulation weights to data
-        if rescale:
-            logger.info("Renormalize simulation prior weights to data")
-            ndata = self.weights_obs.sum()
-            nsig = self.weights_sim.sum()
-            nbkg = self.weights_bkg.sum() if self.datahandle_bkg else 0.
-            nsim = nsig + nbkg
-
-            self.weights_sim *= ndata / nsim
-            if self.datahandle_bkg:
-                self.weights_bkg *= ndata / nsim
-
-        logger.debug("weights_obs.sum() = {}".format(self.weights_obs.sum()))
-        logger.debug("weights_sim.sum() = {}".format(self.weights_sim.sum()))
-        if self.datahandle_bkg:
-            logger.debug("weights_bkg.sum() = {}".format(self.weights_bkg.sum()))
-
-        # plot event weights used in the training
-        wobs_train, wsim_train, wbkg_train = self._get_event_weights()
-        logger.info("Plot event weights used in training")
-        plotting.plot_data_arrays(os.path.join(self.outdir, 'Event_weights_train'), [wsim_train, wobs_train], labels=['Sim.', 'Data'], title='Event weights', xlabel='w (standardized)')
-
-    def _get_event_weights(self, normalize=True, resample=False):
-        wobs = self.weights_obs
-        wsim = self.weights_sim
-        wbkg = self.weights_bkg if self.weights_bkg is not None else None
-
-        if normalize: # normalize to len(weights)
-            logger.debug("Rescale event weights to len(weights)")
-            wobs = wobs / np.mean(wobs)
-            #wsim = wsim / np.mean(wsim)
-            #if wbkg is not None:
-            #    wbkg = wbkg / np.mean(wbkg)
-            wsim = wsim * wobs.sum() / self.weights_obs.sum()
-            if wbkg is not None:
-                wbkg = wbkg * wobs.sum() / self.weights_obs.sum()
-
-        if resample:
-            wobs *= np.random.poisson(1, size=len(wobs))
-
-        return wobs, wsim, wbkg
-
     def _set_up_model(self, input_shape, filepath_save=None, filepath_load=None,
-                      reweight_only=False, nclass=2):
+                      nclass=2):
         # get model
         model = get_model(input_shape, nclass=nclass)
 
@@ -644,50 +758,35 @@ class OmniFoldwBkg(object):
         # load weights from the previous model if available
         if filepath_load:
             logger.info("Load model weights from {}".format(filepath_load))
-            if reweight_only:
-                model.load_weights(filepath_load).expect_partial()
-            else:
-                model.load_weights(filepath_load)
+            model.load_weights(filepath_load)
 
         return model, callbacks
 
     def _set_up_model_step1(self, input_shape, iteration, model_dir,
-                            reweight_only=False, load_previous_iter=True):
+                            load_previous_iter=True):
         # model filepath
         model_fp = os.path.join(model_dir, 'model_step1_{}') if model_dir else None
 
-        if reweight_only:
-            # load the previously trained model from model_dir
-            # apply it directly in reweighting without training
+        # set up model for training
+        if load_previous_iter and iteration > 0:
+            # initialize model based on the previous iteration
             assert(model_fp)
-            return self._set_up_model(input_shape, filepath_save=None, filepath_load=model_fp.format(iteration), reweight_only=True)
+            return self._set_up_model(input_shape, filepath_save=model_fp.format(iteration), filepath_load=model_fp.format(iteration-1))
         else:
-            # set up model for training
-            if load_previous_iter and iteration > 0:
-                # initialize model based on the previous iteration
-                assert(model_fp)
-                return self._set_up_model(input_shape, filepath_save=model_fp.format(iteration), filepath_load=model_fp.format(iteration-1))
-            else:
-                return self._set_up_model(input_shape, filepath_save=model_fp.format(iteration), filepath_load=None)
+            return self._set_up_model(input_shape, filepath_save=model_fp.format(iteration), filepath_load=None)
 
     def _set_up_model_step2(self, input_shape, iteration, model_dir,
-                            reweight_only=False, load_previous_iter=True):
+                            load_previous_iter=True):
         # model filepath
         model_fp = os.path.join(model_dir, 'model_step2_{}') if model_dir else None
 
-        if reweight_only:
-            # load the previously trained model from model_dir
-            # apply it directly in reweighting without training
+        # set up model for training
+        if load_previous_iter and iteration > 0:
+            # initialize model based on the previous iteration
             assert(model_fp)
-            return self._set_up_model(input_shape, filepath_save=None, filepath_load=model_fp.format(iteration), reweight_only=True)
+            return self._set_up_model(input_shape, filepath_save=model_fp.format(iteration), filepath_load=model_fp.format(iteration-1))
         else:
-            # set up model for training
-            if load_previous_iter and iteration > 0:
-                # initialize model based on the previous iteration
-                assert(model_fp)
-                return self._set_up_model(input_shape, filepath_save=model_fp.format(iteration), filepath_load=model_fp.format(iteration-1))
-            else:
-                return self._set_up_model(input_shape, filepath_save=model_fp.format(iteration), filepath_load=None)
+            return self._set_up_model(input_shape, filepath_save=model_fp.format(iteration), filepath_load=None)
 
     def _train_model(self, model, X, Y, w, callbacks=[], val_data=None, figname_preds='', **fitargs):
         if callbacks:
@@ -778,23 +877,17 @@ class OmniFoldwBkg_multi(OmniFoldwBkg):
         self.label_bkg = 2
 
     def _set_up_model_step1(self, input_shape, iteration, model_dir,
-                            reweight_only=False, load_previous_iter=True):
+                            load_previous_iter=True):
         # model filepath
         model_fp = os.path.join(model_dir, 'model_step1_{}') if model_dir else None
 
-        if reweight_only:
-            # load the previously trained model from model_dir
-            # apply it directly in reweighting without training
+        # set up model for training
+        if load_previous_iter and iteration > 0:
+            # initialize model based on the previous iteration
             assert(model_fp)
-            return self._set_up_model(input_shape, filepath_save=None, filepath_load=model_fp.format(iteration), reweight_only=True, nclass=3)
+            return self._set_up_model(input_shape, filepath_save=model_fp.format(iteration), filepath_load=model_fp.format(iteration-1), nclass=3)
         else:
-            # set up model for training
-            if load_previous_iter and iteration > 0:
-                # initialize model based on the previous iteration
-                assert(model_fp)
-                return self._set_up_model(input_shape, filepath_save=model_fp.format(iteration), filepath_load=model_fp.format(iteration-1), nclass=3)
-            else:
-                return self._set_up_model(input_shape, filepath_save=model_fp.format(iteration), filepath_load=None, nclass=3)
+            return self._set_up_model(input_shape, filepath_save=model_fp.format(iteration), filepath_load=None, nclass=3)
 
     def _reweight_step1(self, model, events, plotname=None):
 

--- a/unfold.py
+++ b/unfold.py
@@ -135,7 +135,6 @@ def unfold(**parsed_args):
         data_bkg,
         data_obsbkg,
         parsed_args["plot_correlations"],
-        standardize=True,
         reweighter=rw,
     )
 
@@ -202,7 +201,9 @@ def unfold(**parsed_args):
             ibu = IBU(varname, bins_det, bins_mc,
                       array_obs, array_sim, array_gen, array_simbkg,
                       # use the same weights from OmniFold
-                      unfolder.weights_obs, unfolder.weights_sim, unfolder.weights_bkg,
+                      unfolder.datahandle_obs.get_weights(),
+                      unfolder.datahandle_sig.get_weights(),
+                      unfolder.datahandle_bkg.get_weights() if unfolder.datahandle_bkg is not None else None,
                       iterations=parsed_args['iterations'], # same as OmniFold
                       nresample=25, #parsed_args['nresamples']
                       outdir = unfolder.outdir)

--- a/unfold.py
+++ b/unfold.py
@@ -158,6 +158,7 @@ def unfold(**parsed_args):
         # run training
         unfolder.run(parsed_args['error_type'], parsed_args['nresamples'],
                      load_previous_iteration=False,
+                     load_models_from=parsed_args['load_models'],
                      batch_size=parsed_args['batch_size'])
 
     t_unfold_done = time.time()
@@ -289,6 +290,8 @@ if __name__ == "__main__":
                         default='sumw2', help="Method to evaluate uncertainties")
     parser.add_argument('--batch-size', dest='batch_size', type=int, default=512,
                         help="Batch size for training")
+    parser.add_argument('-l', '--load-models', dest='load_models', type=str,
+                        help="Directory from where to load trained models. If provided, training will be skipped.")
 
     #parser.add_argument('-n', '--normalize',
     #                    action='store_true',


### PR DESCRIPTION
Refactor and clean up some parts of the code that deals with weights:
- OmniFoldwBkg no longer contains weights and arrays for training and reweighting. All of these are accessed via the data handlers.
- Unfolded weights are now scale factors that should be applied to the prior weights instead of the final truth-level event weights.
- Add back an argument '--load-models <output/dir/containing/model/checkpoints>' for unfold.py to load trained models for reweighting