### PR TITLE
Select network type from command line arguments

### DIFF
--- a/python/model.py
+++ b/python/model.py
@@ -100,7 +100,39 @@ def weighted_categorical_crossentropy(y_true, y_pred):
     loss = -event_weights * tf.reduce_sum(y_true * K.log(y_pred), axis=-1)
     return K.mean(loss)
 
-def get_model(input_shape, model_name='dense_3hl', nclass=2):
+def parse_name_for_dense(model_name):
+    """
+    Parse the model name and return a list of number of nodes in each layer in 
+    case of dense neural network.
+
+    Parameters
+    ----------
+    model_name : str
+        Name of the model to set up. In case if dense network, the expected name
+        is "dense_m_n_...", where m, n, ... are number of nodes in each layer 
+        or "dense_mxl", where m is the number of nodes in every layer and l is
+        the number of layers
+
+    Return
+    ------
+    A list of positive int
+    """
+    if 'dense_' in model_name:
+        # expected dense_model name: dense_a_b_...
+        # where a,a,... are number of nodes in each hidden layer
+        # special case: e.g. dense_100x2: two hidden layers each with 100 nodes
+        nodes_list = model_name.lstrip('dense_').split('_')
+        if len(nodes_list)==1 and 'x' in nodes_list[0]:
+            nl = nodes_list[0].split('x')
+            assert(len(nl)==2)
+            # nl[0]: number of nodes in each layer; nl[1]: number layers
+            return [int(nl[0])] * int(nl[1])
+        else:
+            return [int(n) for n in nodes_list]
+    else:
+        return []
+
+def get_model(input_shape, nclass=2, model_name='dense_100x3'):
     """
     Build and compile the classifier for OmniFold.
 
@@ -121,7 +153,13 @@ def get_model(input_shape, model_name='dense_3hl', nclass=2):
         `model.weighted_categorical_crossentropy`, Adam optimizer and
         accuracy metrics.
     """
-    model = eval(model_name+"(input_shape, nclass)")
+    # parse model_name
+    nodes_list = parse_name_for_dense(model_name)
+
+    if nodes_list:
+        model = dense_net(input_shape, nodes_list, nclass)
+    else:
+        model = eval(model_name+"(input_shape, nclass)")
 
     model.compile(loss=weighted_categorical_crossentropy,
                   #loss='categorical_crossentropy',
@@ -132,16 +170,17 @@ def get_model(input_shape, model_name='dense_3hl', nclass=2):
 
     return model
 
-
-def dense_3hl(input_shape, nclass=2):
+def dense_net(input_shape, nnodes=[100, 100, 100], nclass=2):
     """
-    A classifier with 3 dense hidden layers of 100 neurons each. All
-    layers use ReLU activation except the output, which uses softmax.
+    A dense neural network classifer. Number of nodes on each layer is specified
+    by nnodes
 
     Parameters
     ----------
     input_shape : sequence of positive int
         Shape of the input layer of the model.
+    nnodes : sequence of positive int
+        Number of nodes in each hidden layer.
     nclass : positive int, default: 2
         Number of classes in the classifier.
 
@@ -150,45 +189,14 @@ def dense_3hl(input_shape, nclass=2):
     tf.keras.models.Model
     """
     inputs = keras.layers.Input(input_shape)
-    hidden_layer_1 = keras.layers.Dense(100, activation="relu")(inputs)
-    hidden_layer_2 = keras.layers.Dense(100, activation="relu")(hidden_layer_1)
-    hidden_layer_3 = keras.layers.Dense(100, activation="relu")(hidden_layer_2)
-    outputs = keras.layers.Dense(nclass, activation="softmax")(hidden_layer_3)
 
-    nn = keras.models.Model(inputs=inputs, outputs=outputs)
+    prev_layer = inputs
+    for n in nnodes:
+        prev_layer = keras.layers.Dense(n, activation="relu")(prev_layer)
 
-    return nn
+    outputs = keras.layers.Dense(nclass, activation="softmax")(prev_layer)
 
-
-def dense_6hl(input_shape, nclass=2):
-    """
-    A classifier with 6 dense hidden layers of 100 neurons each. All
-    layers use ReLU activation except the output, which uses softmax.
-
-    Parameters
-    ----------
-    input_shape : sequence of positive int
-        Shape of the input layer of the model.
-    nclass : positive int, default: 2
-        Number of classes in the classifier.
-
-    Returns
-    -------
-    tf.keras.models.Model
-    """
-    inputs = keras.layers.Input(input_shape)
-    hidden_layer_1 = keras.layers.Dense(100, activation="relu")(inputs)
-    hidden_layer_2 = keras.layers.Dense(100, activation="relu")(hidden_layer_1)
-    hidden_layer_3 = keras.layers.Dense(100, activation="relu")(hidden_layer_2)
-    hidden_layer_4 = keras.layers.Dense(100, activation="relu")(hidden_layer_3)
-    hidden_layer_5 = keras.layers.Dense(100, activation="relu")(hidden_layer_4)
-    hidden_layer_6 = keras.layers.Dense(100, activation="relu")(hidden_layer_5)
-    outputs = keras.layers.Dense(nclass, activation="softmax")(hidden_layer_6)
-
-    nn = keras.models.Model(inputs=inputs, outputs=outputs)
-
-    return nn
-
+    return keras.models.Model(inputs=inputs, outputs=outputs)
 
 def pfn(input_shape, nclass=2, nlatent=8):
     """

--- a/python/omnifoldwbkg.py
+++ b/python/omnifoldwbkg.py
@@ -22,6 +22,7 @@ class OmniFoldwBkg(object):
         iterations=4,
         outdir=".",
         truth_known=True,
+        model_name='dense_100x3'
     ):
         # list of detector and truth level variable names used in training
         self.vars_reco = variables_det
@@ -45,6 +46,8 @@ class OmniFoldwBkg(object):
         if not os.path.isdir(outdir):
             os.makedirs(outdir)
         self.outdir = outdir.rstrip('/')+'/'
+        # model name
+        self.model_name = model_name
 
     def prepare_inputs(
         self,
@@ -755,7 +758,7 @@ class OmniFoldwBkg(object):
     def _set_up_model(self, input_shape, filepath_save=None, filepath_load=None,
                       nclass=2):
         # get model
-        model = get_model(input_shape, nclass=nclass)
+        model = get_model(input_shape, nclass=nclass, model_name=self.model_name)
 
         # callbacks
         callbacks = get_callbacks(filepath_save)

--- a/unfold.py
+++ b/unfold.py
@@ -101,6 +101,7 @@ def unfold(**parsed_args):
             iterations=parsed_args["iterations"],
             outdir=parsed_args["outputdir"],
             truth_known=parsed_args["truth_known"],
+            model_name=parsed_args['model_name']
         )
     elif parsed_args['background_mode'] == 'negW':
         unfolder = OmniFoldwBkg_negW(
@@ -109,6 +110,7 @@ def unfold(**parsed_args):
             iterations=parsed_args["iterations"],
             outdir=parsed_args["outputdir"],
             truth_known=parsed_args["truth_known"],
+            model_name=parsed_args['model_name']
         )
     elif parsed_args['background_mode'] == 'multiClass':
         unfolder = OmniFoldwBkg_multi(
@@ -117,6 +119,7 @@ def unfold(**parsed_args):
             iterations=parsed_args["iterations"],
             outdir=parsed_args["outputdir"],
             truth_known=parsed_args["truth_known"],
+            model_name=parsed_args['model_name']
         )
     else:
         logger.error("Unknown background mode {}".format(parsed_args['background_mode']))
@@ -298,6 +301,8 @@ if __name__ == "__main__":
                         help="Batch size for training")
     parser.add_argument('-l', '--load-models', dest='load_models', type=str,
                         help="Directory from where to load trained models. If provided, training will be skipped.")
+    parser.add_argument('--model-name', type=str, default='dense_100x3',
+                        help="Name of the model for unfolding")
     parser.add_argument('--legacy-weights', action='store_true',
                         help="If True, load weights in the legacy mode. The unfolded weights read from files are divided by the simulation prior weights. Only useful when --unfolded-weights is not None.")
 


### PR DESCRIPTION
Add an argument `--model-name` in `unfold.py` for selecting network architecture. 

In case of a dense network, the expected name is `dense_m_n_...`, where `m`, `n`, and ... are number of nodes in each hidden layer.
If all layers in the dense network have the same number of nodes, an alternative naming `dense_mxl` is accepted, where `m` is the number of nodes in every layer and `l` is the number of hidden layers. For example, `dense_100x3` corresponds to a dense network with 3 hidden layers each with 100 nodes.