### PR TITLE
(Don't merge into master, just for demonstration) Averaging the output reweight factor from multiple parallel models

### DIFF
--- a/configs/run/quick_run.json
+++ b/configs/run/quick_run.json
@@ -1,6 +1,15 @@
 {
-  "data" : ["/data/ztao/ttbarDiffXs13TeV/latest/mcWAlt/ttbar_nominal/mc16a/ttbar_0_pseudotop_parton_ejets.root"],
-  "signal" : ["/data/ztao/ttbarDiffXs13TeV/latest/mcWAlt/ttbar_nominal/mc16a/ttbar_1_pseudotop_parton_ejets.root"],
+  "data": [
+    "/fast_scratch/xyyu/model_learning_iteration_test_data/ttbar_hw_3_pseudotop_parton_ejets.root"
+  ],
+  "signal": [
+    "/fast_scratch/xyyu/model_learning_iteration_test_data/ttbar_1_pseudotop_parton_ejets.root",
+    "/fast_scratch/xyyu/model_learning_iteration_test_data/ttbar_4_pseudotop_parton_ejets.root",
+    "/fast_scratch/xyyu/model_learning_iteration_test_data/ttbar_5_pseudotop_parton_ejets.root",
+    "/fast_scratch/xyyu/model_learning_iteration_test_data/ttbar_6_pseudotop_parton_ejets.root"
+  ],
+  "nresamples": 2,
+  "error_type": "bootstrap_full",
   "observable_config" : "configs/observables/vars_ttbardiffXs_pseudotop.json",
   "iterations" : 3,
   "truth_known" : true,

--- a/python/modelUtils.py
+++ b/python/modelUtils.py
@@ -11,6 +11,8 @@ from sklearn.model_selection import train_test_split
 
 import plotter
 
+n_models_in_parallel = 20
+
 import logging
 logger = logging.getLogger('model')
 
@@ -229,16 +231,28 @@ def dense_net(input_shape, nnodes=[100, 100, 100], nclass=2):
     -------
     tf.keras.models.Model
     """
-    inputs = keras.layers.Input(input_shape)
 
-    prev_layer = inputs
-    for n in nnodes:
-        prev_layer = keras.layers.Dense(n, activation="relu")(prev_layer)
+    outputs = []
+    input_layer = keras.layers.Input(input_shape)
+    for i in range(n_models_in_parallel):
 
-    #outputs = keras.layers.Dense(nclass, activation="softmax")(prev_layer)
-    outputs = keras.layers.Dense(1, activation="sigmoid")(prev_layer)
+        prev_layer = input_layer
+        for n in nnodes:
+            prev_layer = keras.layers.Dense(n, activation="relu")(prev_layer)
+        
+        output_layer = keras.layers.Dense(1, activation="sigmoid")(prev_layer)
+        outputs += [output_layer]
 
-    return keras.models.Model(inputs=inputs, outputs=outputs)
+    # inputs = keras.layers.Input(input_shape)
+    outputs = keras.layers.Average()(outputs)
+    # prev_layer = inputs
+    # for n in nnodes:
+    #     prev_layer = keras.layers.Dense(n, activation="relu")(prev_layer)
+
+    ## outputs = keras.layers.Dense(nclass, activation="softmax")(prev_layer)
+    # outputs = keras.layers.Dense(1, activation="sigmoid")(prev_layer)
+
+    return keras.models.Model(inputs=input_layer, outputs=outputs)
 
 def pfn(input_shape, nclass=2, nlatent=8):
     """

--- a/python/modelUtils.py
+++ b/python/modelUtils.py
@@ -11,7 +11,7 @@ from sklearn.model_selection import train_test_split
 
 import plotter
 
-n_models_in_parallel = 20
+n_models_in_parallel = 5
 
 import logging
 logger = logging.getLogger('model')
@@ -244,7 +244,12 @@ def dense_net(input_shape, nnodes=[100, 100, 100], nclass=2):
         outputs += [output_layer]
 
     # inputs = keras.layers.Input(input_shape)
-    outputs = keras.layers.Average()(outputs)
+
+    # outputs = keras.layers.Average()(outputs)
+
+    combined = keras.layers.Concatenate()(outputs)
+    # outputs = keras.layers.Dense(1, activation="sigmoid")(combined)
+
     # prev_layer = inputs
     # for n in nnodes:
     #     prev_layer = keras.layers.Dense(n, activation="relu")(prev_layer)
@@ -252,7 +257,7 @@ def dense_net(input_shape, nnodes=[100, 100, 100], nclass=2):
     ## outputs = keras.layers.Dense(nclass, activation="softmax")(prev_layer)
     # outputs = keras.layers.Dense(1, activation="sigmoid")(prev_layer)
 
-    return keras.models.Model(inputs=input_layer, outputs=outputs)
+    return keras.models.Model(inputs=input_layer, outputs=combined)
 
 def pfn(input_shape, nclass=2, nlatent=8):
     """

--- a/python/omnifold.py
+++ b/python/omnifold.py
@@ -57,6 +57,7 @@ def reweight(model, events, batch_size, figname=None):
     preds = model.predict(dataset)
     preds = np.squeeze(preds)
     r = np.nan_to_num( preds / (1. - preds) )
+    r = np.mean(r,axis=1) # average the reweight factor produced by the parallel layers
 
     if figname: # plot the distribution
         logger.info(f"Plot likelihood ratio distribution {figname}")


### PR DESCRIPTION
The model output is each converted to reweight factor from the original `r = np.nan_to_num( preds / (1. - preds) )`. They are then averaged to a single reweight factor.