### PR TITLE
replacement callback for current early stopping

### DIFF
--- a/python/callbacks.py
+++ b/python/callbacks.py
@@ -87,7 +87,7 @@ class EarlyLocking(keras.callbacks.Callback):
             new_monitor_val = logs[self._monitor_key(model_idx)]
             if new_monitor_val < self.best_monitor_value[model_idx]:
                 # if we achieved better result than before
-                logger.debug("saving best set of weight for parallel model {0}".format(model_idx))
+                logger.debug("improvement by {0}, saving best set of weight for parallel model {1}".format(self.best_monitor_value[model_idx] - new_monitor_val, model_idx))
                 # update best weight
                 for layer in self.model.layers:
                     if "model_{0}".format(model_idx) in layer.name:

--- a/python/callbacks.py
+++ b/python/callbacks.py
@@ -77,6 +77,8 @@ class EarlyLocking(keras.callbacks.Callback):
         self.counters -= 1
         # initialize self.best_weights if this is the first epoch
         if self.best_weights == None:
+            # the initialization should not be count towards patience
+            self.counters += 1
             logger.debug("loading initial set of weights")
             self.best_weights = {}
             for layer in self.model.layers:
@@ -84,7 +86,8 @@ class EarlyLocking(keras.callbacks.Callback):
 
         # update counter, best_weights, and best_monitor_value if improvement is seen for each individual models
         for model_idx in range(self.n_models_in_parallel):
-            new_monitor_val = logs[self._monitor_key(model_idx)]
+            monitor_key = self._monitor_key(model_idx) if self.n_models_in_parallel > 1 else self.monitor
+            new_monitor_val = logs[monitor_key]
             if new_monitor_val < self.best_monitor_value[model_idx]:
                 # if we achieved better result than before
                 logger.debug("improvement by {0}, saving best set of weight for parallel model {1}".format(self.best_monitor_value[model_idx] - new_monitor_val, model_idx))

--- a/python/callbacks.py
+++ b/python/callbacks.py
@@ -119,5 +119,3 @@ class EarlyLocking(keras.callbacks.Callback):
             print("Early Stopping")
             self.model.stop_training = True
 
-        print(np.sum([keras.backend.count_params(w) for w in self.model.trainable_weights]))
-

--- a/python/callbacks.py
+++ b/python/callbacks.py
@@ -77,19 +77,17 @@ class EarlyLocking(keras.callbacks.Callback):
         self.counters -= 1
         # initialize self.best_weights if this is the first epoch
         if self.best_weights == None:
-            print("loading initial set of weights")
+            logger.debug("loading initial set of weights")
             self.best_weights = {}
             for layer in self.model.layers:
                 self.best_weights[layer.name] = layer.get_weights()
-            print("initial weight load complete")
 
-        print(logs)
         # update counter, best_weights, and best_monitor_value if improvement is seen for each individual models
         for model_idx in range(self.n_models_in_parallel):
             new_monitor_val = logs[self._monitor_key(model_idx)]
             if new_monitor_val < self.best_monitor_value[model_idx]:
                 # if we achieved better result than before
-                print("updating current best")
+                logger.debug("saving best set of weight for parallel model {0}".format(model_idx))
                 # update best weight
                 for layer in self.model.layers:
                     if "model_{0}".format(model_idx) in layer.name:
@@ -100,13 +98,11 @@ class EarlyLocking(keras.callbacks.Callback):
 
                 # update best_monitor_value
                 self.best_monitor_value[model_idx] = new_monitor_val
-        print(self.counters)
-        print(self.best_monitor_value)
 
         # lock models and restore best weight when its counter goes to 0
         for model_idx in range(self.n_models_in_parallel):
             if self.counters[model_idx] == 0:
-                print("restoring best weight for model"+str(model_idx))
+                logger.debug("restoring best set of weights for parallel model {0}".format(model_idx))
                 # restore best weights and set them to untrainable
                 for layer_name in self.best_weights:
                     if "model_{0}".format(model_idx) in layer_name:
@@ -116,6 +112,6 @@ class EarlyLocking(keras.callbacks.Callback):
 
         # early stopping when all counters are less than or equal to 0
         if np.all(self.counters <= 0):
-            print("Early Stopping")
+            logger.debug("early stopping")
             self.model.stop_training = True
 

--- a/python/callbacks.py
+++ b/python/callbacks.py
@@ -49,8 +49,9 @@ class EarlyLocking(keras.callbacks.Callback):
         initialization at the before any epoch starts
         """
         self.best_weights = None
+        self.best_monitor_value = np.full(self.n_models_in_parallel, np.Infinity)
         # a count down for each parallel model before it goes to 0
-        self.counters = np.zeros(self.n_models_in_parallel) + self.patience
+        self.counters = np.full(self.n_models_in_parallel, self.patience)
 
     def on_epoch_end(self, epoch, logs=None):
         # initialize self.best_weights if this is the first epoch
@@ -60,6 +61,9 @@ class EarlyLocking(keras.callbacks.Callback):
             for layer in self.model.layers:
                 self.best_weights[layer.name] = layer.get_weights()
             print("initial weight load complete")
+
+        # update counter, best_weights, and best_monitor_value if improvement is seen for each individual models
+
 
         # just keeping record of how to do this, remove when not needed
         once = True

--- a/python/callbacks.py
+++ b/python/callbacks.py
@@ -88,7 +88,8 @@ class EarlyLocking(keras.callbacks.Callback):
         for model_idx in range(self.n_models_in_parallel):
             monitor_key = self._monitor_key(model_idx) if self.n_models_in_parallel > 1 else self.monitor
             new_monitor_val = logs[monitor_key]
-            if new_monitor_val < self.best_monitor_value[model_idx]:
+            # if new best is achieved, and the model is still in training (not due to random fluctuations)
+            if new_monitor_val < self.best_monitor_value[model_idx] and self.counters[model_idx] >= 0:
                 # if we achieved better result than before
                 logger.debug("improvement by {0}, saving best set of weight for parallel model {1}".format(self.best_monitor_value[model_idx] - new_monitor_val, model_idx))
                 # update best weight

--- a/python/callbacks.py
+++ b/python/callbacks.py
@@ -14,6 +14,13 @@ class PrintLearningRate(keras.callbacks.Callback):
         logger.debug("Current learning rate is {0}".format(learning_rate))
 
 class EarlyLocking(keras.callbacks.Callback):
+    """
+    Monitors the selected performance parameter for all the parallel models. Once the epoch without improvement for a parallel model exceeds
+    set patience, it is locked out from training with trainable set to false. Its weights will be restored to that of patience epoch ago (best result).
+    The entire training process will be terminated when every parallel model has stopped improving.
+    """
+    def __init__(self, )
+
     def on_epoch_end(self, epoch, logs=None):
         for key, value in self.model._get_trainable_state().items():
             print(key, value)

--- a/python/callbacks.py
+++ b/python/callbacks.py
@@ -53,6 +53,15 @@ class EarlyLocking(keras.callbacks.Callback):
         self.counters = np.zeros(self.n_models_in_parallel) + self.patience
 
     def on_epoch_end(self, epoch, logs=None):
+        # initialize self.best_weights if this is the first epoch
+        if self.best_weights == None:
+            print("loading initial set of weights")
+            self.best_weights = {}
+            for layer in self.model.layers:
+                self.best_weights[layer.name] = layer.get_weights()
+            print("initial weight load complete")
+
+        # just keeping record of how to do this, remove when not needed
         once = True
         for key, value in self.model._get_trainable_state().items():
             print(key, value)

--- a/python/callbacks.py
+++ b/python/callbacks.py
@@ -13,3 +13,10 @@ class PrintLearningRate(keras.callbacks.Callback):
         learning_rate = self.model.optimizer._decayed_lr(float32).numpy()
         logger.debug("Current learning rate is {0}".format(learning_rate))
 
+class EarlyLocking(keras.callbacks.Callback):
+    def on_epoch_end(self, epoch, logs=None):
+        for key, value in self.model._get_trainable_state().items():
+            print(key, value)
+            if(key.name == "dense_4") and epoch > 2:
+                key.trainable = False
+

--- a/python/callbacks.py
+++ b/python/callbacks.py
@@ -19,7 +19,26 @@ class EarlyLocking(keras.callbacks.Callback):
     set patience, it is locked out from training with trainable set to false. Its weights will be restored to that of patience epoch ago (best result).
     The entire training process will be terminated when every parallel model has stopped improving.
     """
-    def __init__(self, )
+    def __init__(self, monitor, patience, verbose, restore_best_weights):
+        """
+        initalize the early locking callback
+
+        arguments
+        ---------
+        monitor: str
+            a performance monitor such as "val_loss" or "loss"
+        patience: int
+            the number of epoch to run before stopping training after the monitor has stopped improving
+        verbose: int
+            verbosity of the callback, it has no effect at the moment
+        restore_best_weights: boolean
+            whether the best weights for each parallel model will be restored
+        """
+        super(EarlyLocking, self).__init__()
+        self.monitor = monitor
+        self.patience = patience
+        self.verbose = verbose
+        self.restore_best_weights = restore_best_weights
 
     def on_epoch_end(self, epoch, logs=None):
         for key, value in self.model._get_trainable_state().items():

--- a/python/callbacks.py
+++ b/python/callbacks.py
@@ -4,6 +4,7 @@ this file includes custom callback class(es) for tensorflow keras
 from tensorflow import keras
 from tensorflow import float32
 import numpy as np
+from layer_namer import _layer_name
 
 import logging
 logger = logging.getLogger('callbacks')
@@ -53,7 +54,22 @@ class EarlyLocking(keras.callbacks.Callback):
         # a count down for each parallel model before it goes to 0
         self.counters = np.full(self.n_models_in_parallel, self.patience)
 
+    def _monitor_key(self, parallel_model_idx):
+        """
+        get the name of the monitor value for the parallel model, following keras' naming convention
+
+        arguments
+        ---------
+        parallel_model_idx: int
+            the index of the parallel model
+        """
+        if self.monitor == "val_loss":
+            return "val_"+_layer_name(parallel_model_idx, "output")+"_loss"
+        else:
+            return _layer_name(parallel_model_idx, "output")+"_"+self.monitor
+
     def on_epoch_end(self, epoch, logs=None):
+        self.counters -= 1
         # initialize self.best_weights if this is the first epoch
         if self.best_weights == None:
             print("loading initial set of weights")
@@ -62,7 +78,27 @@ class EarlyLocking(keras.callbacks.Callback):
                 self.best_weights[layer.name] = layer.get_weights()
             print("initial weight load complete")
 
+        print(logs)
         # update counter, best_weights, and best_monitor_value if improvement is seen for each individual models
+        for model_idx in range(self.n_models_in_parallel):
+            new_monitor_val = logs[self._monitor_key(model_idx)]
+            if new_monitor_val < self.best_monitor_value[model_idx]:
+                # if we achieved better result than before
+                print("updating current best")
+                # update best weight
+                for layer in self.model.layers:
+                    if "model_{0}".format(model_idx) in layer.name:
+                        self.best_weights[layer.name] = layer.get_weights()
+
+                # reset counter
+                self.counters[model_idx] = self.patience
+
+                # update best_monitor_value
+                self.best_monitor_value[model_idx] = new_monitor_val
+        print(self.counters)
+        print(self.best_monitor_value)
+                    
+
 
 
         # just keeping record of how to do this, remove when not needed

--- a/python/layer_namer.py
+++ b/python/layer_namer.py
@@ -1,0 +1,28 @@
+"""
+this file is necessary to be used by (currently) both callbacks and modelUtil
+it ensures the same naming convention is used
+and it avoid error from circular import
+"""
+
+def _layer_name(parallel_model_idx, layer_type, dense_depth = 0):
+    """
+    give proper name to a layer, necessary to follow name conventions since they can be used by other moduels to identify models and layers
+
+    arguments
+    ---------
+    parallel_model_idx: int
+        unique index from 0 to n_models_in_parallel for each parallel model
+    layer_type: str
+        type of the layer, currently only one of "input", "output", and "dense"
+    dense_depth: int
+        indicating this layer is the dense_depth th dense layer
+
+    returns
+    -------
+    name: str
+        proper name for the layer following the same naming convention
+    """
+    if layer_type == "input" or layer_type == "output":
+        return "model_{0}_{1}".format(parallel_model_idx, layer_type)
+    elif layer_type == "dense":
+        return "model_{0}_{1}_{2}".format(parallel_model_idx, layer_type, dense_depth)

--- a/python/modelUtils.py
+++ b/python/modelUtils.py
@@ -32,7 +32,7 @@ def get_callbacks(model_filepath=None):
     -------
     sequence of `tf.keras.callbacks.Callback`
     """
-    EarlyLockingCallback = EarlyLocking(monitor="val_loss", patience=10, verbose=1, restore_best_weights=True)
+    EarlyLockingCallback = EarlyLocking(monitor="val_loss", patience=10, verbose=1, restore_best_weights=True, n_models_in_parallel=n_models_in_parallel)
 
     lr_callbacks = get_lr_scheduler().get_callbacks()
 
@@ -231,13 +231,13 @@ def dense_net(input_shape, nnodes=[100, 100, 100], nclass=2):
     inputs, outputs = [], []
 
     for i in range(n_models_in_parallel):
-        input_layer = keras.layers.Input(input_shape)
+        input_layer = keras.layers.Input(input_shape, name="model_{0}_input".format(i))
         prev_layer = input_layer
-        for n in nnodes:
-            prev_layer = keras.layers.Dense(n, activation="relu")(prev_layer)
+        for idx,n in enumerate(nnodes):
+            prev_layer = keras.layers.Dense(n, activation="relu", name="model_{0}_dense_{1}".format(i, idx))(prev_layer)
 
         #output_layer = keras.layers.Dense(nclass, activation="softmax")(prev_layer)
-        output_layer = keras.layers.Dense(1, activation="sigmoid")(prev_layer)
+        output_layer = keras.layers.Dense(1, activation="sigmoid", name="model_{0}_output".format(i))(prev_layer)
 
         inputs += [input_layer]
         outputs += [output_layer]

--- a/python/modelUtils.py
+++ b/python/modelUtils.py
@@ -32,11 +32,7 @@ def get_callbacks(model_filepath=None):
     -------
     sequence of `tf.keras.callbacks.Callback`
     """
-    EarlyStopping = keras.callbacks.EarlyStopping(
-        monitor="val_loss", patience=10, verbose=1, restore_best_weights=True
-    )
-
-    EarlyLockingCallback = EarlyLocking()
+    EarlyLockingCallback = EarlyLocking(monitor="val_loss", patience=10, verbose=1, restore_best_weights=True)
 
     lr_callbacks = get_lr_scheduler().get_callbacks()
 
@@ -53,9 +49,9 @@ def get_callbacks(model_filepath=None):
 
         logger_fp = model_filepath + "_history.csv"
         CSVLogger = keras.callbacks.CSVLogger(filename=logger_fp, append=False)
-        return [CheckPoint, CSVLogger, EarlyStopping, EarlyLockingCallback] + lr_callbacks
+        return [CheckPoint, CSVLogger, EarlyLockingCallback] + lr_callbacks
     else:
-        return [EarlyStopping, EarlyLockingCallback] + lr_callbacks
+        return [EarlyLockingCallback] + lr_callbacks
 
 def weighted_binary_crossentropy(y_true, y_pred):
     """

--- a/python/modelUtils.py
+++ b/python/modelUtils.py
@@ -189,8 +189,8 @@ def train_model(model, X, Y, w, callbacks=[], figname='', batch_size=32768, epoc
         # train_dictionary["input_"+str(i)], val_dictionary["input_"+str(i)] = X_train, X_val
         # train_yw_dictionary["output_"+str(i)], val_yw_dictionary["output_"+str(i)] = np.column_stack((Y_train, w_train)), np.column_stack((Y_val, w_val))
 
-        train_dictionary["input_"+str(i)], val_dictionary["input_"+str(i)] = X_train, X_val
-        train_y_dictionary["output_"+str(i)], val_y_dictionary["output_"+str(i)] = Y_train , Y_val
+        train_dictionary[_layer_name(i, "input")], val_dictionary[_layer_name(i, "input")] = X_train, X_val
+        train_y_dictionary[_layer_name(i, "output")], val_y_dictionary[_layer_name(i, "output")] = Y_train , Y_val
 
         train_w += [w_train]
         val_w += [w_val]

--- a/python/modelUtils.py
+++ b/python/modelUtils.py
@@ -32,7 +32,7 @@ def get_callbacks(model_filepath=None):
     -------
     sequence of `tf.keras.callbacks.Callback`
     """
-    EarlyLockingCallback = EarlyLocking(monitor="val_loss", patience=1, verbose=1, restore_best_weights=True, n_models_in_parallel=n_models_in_parallel)
+    EarlyLockingCallback = EarlyLocking(monitor="val_loss", patience=10, verbose=1, restore_best_weights=True, n_models_in_parallel=n_models_in_parallel)
 
     lr_callbacks = get_lr_scheduler().get_callbacks()
 

--- a/python/modelUtils.py
+++ b/python/modelUtils.py
@@ -14,7 +14,7 @@ from layer_namer import _layer_name
 from callbacks import EarlyLocking
 import plotter
 
-n_models_in_parallel = 2
+n_models_in_parallel = 1
 
 import logging
 logger = logging.getLogger('model')
@@ -32,7 +32,7 @@ def get_callbacks(model_filepath=None):
     -------
     sequence of `tf.keras.callbacks.Callback`
     """
-    EarlyLockingCallback = EarlyLocking(monitor="val_loss", patience=10, verbose=1, restore_best_weights=True, n_models_in_parallel=n_models_in_parallel)
+    EarlyLockingCallback = EarlyLocking(monitor="val_loss", patience=1, verbose=1, restore_best_weights=True, n_models_in_parallel=n_models_in_parallel)
 
     lr_callbacks = get_lr_scheduler().get_callbacks()
 

--- a/python/modelUtils.py
+++ b/python/modelUtils.py
@@ -10,10 +10,11 @@ from tensorflow.keras import layers
 import tensorflow.keras.backend as K
 from sklearn.model_selection import train_test_split
 from lrscheduler import get_lr_scheduler
+from callbacks import EarlyLocking
 
 import plotter
 
-n_models_in_parallel = 1
+n_models_in_parallel = 2
 
 import logging
 logger = logging.getLogger('model')
@@ -35,6 +36,8 @@ def get_callbacks(model_filepath=None):
         monitor="val_loss", patience=10, verbose=1, restore_best_weights=True
     )
 
+    EarlyLockingCallback = EarlyLocking()
+
     lr_callbacks = get_lr_scheduler().get_callbacks()
 
     if model_filepath:
@@ -50,9 +53,9 @@ def get_callbacks(model_filepath=None):
 
         logger_fp = model_filepath + "_history.csv"
         CSVLogger = keras.callbacks.CSVLogger(filename=logger_fp, append=False)
-        return [CheckPoint, CSVLogger, EarlyStopping] + lr_callbacks
+        return [CheckPoint, CSVLogger, EarlyStopping, EarlyLockingCallback] + lr_callbacks
     else:
-        return [EarlyStopping] + lr_callbacks
+        return [EarlyStopping, EarlyLockingCallback] + lr_callbacks
 
 def weighted_binary_crossentropy(y_true, y_pred):
     """

--- a/python/modelUtils.py
+++ b/python/modelUtils.py
@@ -11,7 +11,7 @@ import tensorflow.keras.backend as K
 from sklearn.model_selection import train_test_split
 from lrscheduler import get_lr_scheduler
 from layer_namer import _layer_name
-
+from callbacks import EarlyLocking
 import plotter
 
 n_models_in_parallel = 2
@@ -32,8 +32,6 @@ def get_callbacks(model_filepath=None):
     -------
     sequence of `tf.keras.callbacks.Callback`
     """
-    # moving import here since otherwise it will result in circular import
-    from callbacks import EarlyLocking
     EarlyLockingCallback = EarlyLocking(monitor="val_loss", patience=10, verbose=1, restore_best_weights=True, n_models_in_parallel=n_models_in_parallel)
 
     lr_callbacks = get_lr_scheduler().get_callbacks()

--- a/python/modelUtils.py
+++ b/python/modelUtils.py
@@ -15,7 +15,7 @@ from layer_namer import _layer_name
 from callbacks import EarlyLocking
 import plotter
 
-n_models_in_parallel = 4
+n_models_in_parallel = 1
 
 import logging
 logger = logging.getLogger('model')

--- a/python/modelUtils.py
+++ b/python/modelUtils.py
@@ -15,7 +15,7 @@ from layer_namer import _layer_name
 from callbacks import EarlyLocking
 import plotter
 
-n_models_in_parallel = 1
+n_models_in_parallel = 4
 
 import logging
 logger = logging.getLogger('model')


### PR DESCRIPTION
this new callback will replace the old early stopping callback. It will lock the parallel models that are not improving by restoring their best weight and setting them to untrainable, effetely freeze them in their best result.