### PR TITLE
saving best epoch weight only once at the end of training

### DIFF
--- a/configs/run/quick_run.json
+++ b/configs/run/quick_run.json
@@ -8,5 +8,6 @@
   "batch_size" : 20000,
   "plot_verbosity" : 3,
   "outputdir" : "output_tmp",
-  "reweight_data" : "linear_th_pt"
+  "reweight_data" : "linear_th_pt",
+  "load_models": "output_tmp"
 }

--- a/configs/run/quick_run.json
+++ b/configs/run/quick_run.json
@@ -8,6 +8,5 @@
   "batch_size" : 20000,
   "plot_verbosity" : 3,
   "outputdir" : "output_tmp",
-  "reweight_data" : "linear_th_pt",
-  "load_models": "output_tmp"
+  "reweight_data" : "linear_th_pt"
 }

--- a/python/modelUtils.py
+++ b/python/modelUtils.py
@@ -38,19 +38,9 @@ def get_callbacks(model_filepath=None):
     lr_callbacks = get_lr_scheduler().get_callbacks()
 
     if model_filepath:
-        # checkpoint_fp = model_filepath + '_Epoch-{epoch}'
-        checkpoint_fp = model_filepath
-        CheckPoint = keras.callbacks.ModelCheckpoint(
-            filepath=checkpoint_fp,
-            verbose=1,
-            monitor="val_loss",
-            save_best_only=True,
-            save_weights_only=True,
-        )
-
         logger_fp = model_filepath + "_history.csv"
         CSVLogger = keras.callbacks.CSVLogger(filename=logger_fp, append=False)
-        return [CheckPoint, CSVLogger, EarlyStopping] + lr_callbacks
+        return [CSVLogger, EarlyStopping] + lr_callbacks
     else:
         return [EarlyStopping] + lr_callbacks
 
@@ -205,7 +195,7 @@ def train_model(model, X, Y, w, callbacks=[], figname='', batch_size=32768, epoc
         model.fit(X_train_list, Yw_train_list, validation_data=(X_val_list, Yw_val_list), **fitargs)
     
     if model_filepath:
-        model.save_weights(model_filepath+"test")
+        model.save_weights(model_filepath)
 
     # FIXME: Y and w are stacked together into Yw and requires separating for plotting
     # if figname:

--- a/python/modelUtils.py
+++ b/python/modelUtils.py
@@ -182,7 +182,7 @@ def get_model(input_shape, nclass=2, model_name='dense_100x3'):
 
     return model
 
-def train_model(model, X, Y, w, callbacks=[], figname='', batch_size=32768, epochs=100, verbose=1):
+def train_model(model, X, Y, w, callbacks=[], figname='', batch_size=32768, epochs=100, verbose=1, model_filepath=None):
 
     # initalize empty lists
     X_train_list, X_val_list, Yw_train_list, Yw_val_list = [], [], [], []
@@ -203,6 +203,9 @@ def train_model(model, X, Y, w, callbacks=[], figname='', batch_size=32768, epoc
         model.fit(X_train_list[0], Yw_train_list[0], validation_data=(X_val_list[0], Yw_val_list[0]), **fitargs)
     else:
         model.fit(X_train_list, Yw_train_list, validation_data=(X_val_list, Yw_val_list), **fitargs)
+    
+    if model_filepath:
+        model.save(model_filepath+"test")
 
     # FIXME: Y and w are stacked together into Yw and requires separating for plotting
     # if figname:

--- a/python/modelUtils.py
+++ b/python/modelUtils.py
@@ -13,7 +13,7 @@ from lrscheduler import get_lr_scheduler
 
 import plotter
 
-n_models_in_parallel = 1
+n_models_in_parallel = 5
 
 import logging
 logger = logging.getLogger('model')

--- a/python/modelUtils.py
+++ b/python/modelUtils.py
@@ -13,7 +13,7 @@ from lrscheduler import get_lr_scheduler
 
 import plotter
 
-n_models_in_parallel = 5
+n_models_in_parallel = 1
 
 import logging
 logger = logging.getLogger('model')

--- a/python/modelUtils.py
+++ b/python/modelUtils.py
@@ -205,7 +205,7 @@ def train_model(model, X, Y, w, callbacks=[], figname='', batch_size=32768, epoc
         model.fit(X_train_list, Yw_train_list, validation_data=(X_val_list, Yw_val_list), **fitargs)
     
     if model_filepath:
-        model.save(model_filepath+"test")
+        model.save_weights(model_filepath+"test")
 
     # FIXME: Y and w are stacked together into Yw and requires separating for plotting
     # if figname:

--- a/python/omnifold.py
+++ b/python/omnifold.py
@@ -230,7 +230,8 @@ def omnifold(
             train_model(model_step1, X_step1, Y_step1, w_step1,
                         callbacks = cb_step1,
                         #figname = fname_preds,
-                        batch_size=batch_size, epochs=epochs, verbose=verbose
+                        batch_size=batch_size, epochs=epochs, verbose=verbose,
+                        model_filepath=file_path_save("model_step1", i, save_models_to)
                         )
             logger.info("Training done")
 
@@ -261,7 +262,7 @@ def omnifold(
                 logger.info("Start training")
                 train_model(model_step1b, X_step1b, Y_step1b, w_step1b,
                             callbacks = cb_step1b, batch_size=batch_size,
-                            epochs=epochs, verbose=verbose)
+                            epochs=epochs, verbose=verbose, model_filepath=file_path_save("model_step1b", i, save_models_to))
                 logger.info("Training done")
 
             # reweight
@@ -296,7 +297,8 @@ def omnifold(
             train_model(model_step2, X_step2, Y_step2, w_step2,
                         callbacks = cb_step2,
                         #figname = fname_preds,
-                        batch_size=batch_size, epochs=epochs, verbose=verbose)
+                        batch_size=batch_size, epochs=epochs, verbose=verbose,
+                        model_filepath=file_path_save("model_step2", i, save_models_to))
             logger.info("Training done")
 
         # reweight
@@ -326,7 +328,8 @@ def omnifold(
                 logger.info("Start training")
                 train_model(model_step2b, X_step2b, Y_step2b, w_step2b,
                             callbacks = cb_step2b, batch_size=batch_size,
-                            epochs=epochs, verbose=verbose)
+                            epochs=epochs, verbose=verbose,
+                            model_filepath=file_path_save("model_step2b", i, save_models_to))
                 logger.info("Training done")
 
             # reweight

--- a/python/omnifold.py
+++ b/python/omnifold.py
@@ -15,6 +15,31 @@ logger.setLevel(logging.DEBUG)
 
 B_TO_MB = 2**-20 # constant for converting size in bytes to MBs
 
+def file_path_save(name_prefix="model", iteration=0, save_models_to=""):
+    """
+    assemble the path to save model related files
+
+    arguments
+    ---------
+    name_prefix: str
+        prefix of the model name
+    iteratino: int
+        iteration index
+    save_model_to: str
+        directory to save the trained model to
+
+    returns
+    -------
+    filepath_save: str
+        path to save model files if save_model_to is specified, otherwise None
+    """
+    if save_models_to:
+        # name of the model checkpoint
+        mname = name_prefix + "_iter{}".format(iteration)
+        return os.path.join(save_models_to, mname)
+    else:
+        return None
+
 def set_up_model(
     model_type, # str, type of the network
     input_shape, # tuple, shape of the input layer

--- a/python/omnifold.py
+++ b/python/omnifold.py
@@ -59,6 +59,7 @@ def set_up_model(
     
     # load trained model if needed
     if load_models_from:
+        mname = name_prefix + "_iter{}".format(iteration)
         filepath_load = os.path.join(load_models_from, mname)
         model.load_weights(filepath_load).expect_partial()
         logger.info(f"Load model from {filepath_load}")

--- a/python/omnifold.py
+++ b/python/omnifold.py
@@ -52,14 +52,8 @@ def set_up_model(
 
     # get network
     model = get_model(input_shape, nclass=2, model_name=model_type)
-
-    # name of the model checkpoint
-    mname = name_prefix + "_iter{}".format(iteration)
-
-    # callbacks
-    filepath_save = None
-    if save_models_to:
-        filepath_save = os.path.join(save_models_to, mname)
+    
+    filepath_save = file_path_save(name_prefix, iteration, save_models_to)
 
     callbacks = get_callbacks(filepath_save)
     


### PR DESCRIPTION
The old Checkpoint callback is removed and replaced with a single saving operation after model training finishes. The old behaviour is that each time the monitored value is improved, the best weight checkpoint file will be rewritten. The new behaviour is that the best weight checkpoint will be saved only once per training.
The saved weight checkpoint has the same naming and format (weight only as checkpoint) as before, so loading is not affected.